### PR TITLE
Fix fatal error in getAllPages() on PHP 7

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,3 @@
-### New Features
+### Bug Fix
 
-Implement the new (Custom Template Associations)[https://developer.bigcommerce.com/api-reference/store-management/custom-template-associations]
-API.
+Fix issue with all batch operations under PHP 7.4

--- a/src/BigCommerce/Api/Generic/BatchUpdateResource.php
+++ b/src/BigCommerce/Api/Generic/BatchUpdateResource.php
@@ -10,7 +10,7 @@ use Psr\Http\Message\ResponseInterface;
 trait BatchUpdateResource
 {
     abstract public function batchUpdate(array $resources): PaginatedResponse;
-    abstract public function multipleResourcesEndpoint(): string;
+    abstract protected function multipleResourcesEndpoint(): string;
     abstract public function getClient(): Client;
 
     protected function maxBatchSize(): int


### PR DESCRIPTION
Make the signature for `BatchUpdateResource::multipleResourcesEndpoint` _protected_ to match ResourceApi definition. 

Closes #39