### PR TITLE
fix: make product variant sku_id nullable

### DIFF
--- a/src/BigCommerce/ResourceModels/Catalog/Product/ProductVariant.php
+++ b/src/BigCommerce/ResourceModels/Catalog/Product/ProductVariant.php
@@ -9,7 +9,7 @@ class ProductVariant extends ResourceModel
     public int $id;
     public int $product_id;
     public string $sku;
-    public int $sku_id;
+    public ?int $sku_id;
     public ?float $price;
     public ?float $calculated_price;
     public ?float $sale_price;


### PR DESCRIPTION
Makes the `sku_id` of a `ProductVariant` nullable as according to the [API reference](https://developer.bigcommerce.com/api-reference/store-management/catalog/product-variants/getvariantbyid).
