### PR TITLE
Fix/use params with get product

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,4 @@
 ### Bug Fix
 
-Fix issue with Metafield APIs missing create and update endpoints.
+Fix issue with ProductVariant::sku_id not being nullable #47 (thanks @Yorgv)
+

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,13 @@
+### New Features
+
+Allow the use of [parameters in ProductsApi::Get](https://developer.bigcommerce.com/api-reference/store-management/catalog/products/getproductbyid).
+
+Here's an example using PHP 8:
+
+```php
+$product = $api->catalog()->product(123)->get(include_fields: ['description', 'sku'])->getProduct();
+```
+
 ### Bug Fix
 
 Fix issue with ProductVariant::sku_id not being nullable #47 (thanks @Yorgv)

--- a/src/BigCommerce/Api/Catalog/ProductsApi.php
+++ b/src/BigCommerce/Api/Catalog/ProductsApi.php
@@ -24,13 +24,30 @@ class ProductsApi extends ResourceWithBatchUpdateApi
     public const FILTER_SKU_IS      = 'sku';
 
     public const FILTER_INCLUDE_FIELDS = 'include_fields';
+    public const FILTER_EXCLUDE_FIELDS = 'exclude_fields';
 
     public const FILTER_INCLUDE     = 'include';
     public const INCLUDE_MODIFIERS = 'modifiers';
 
-    public function get(): ProductResponse
-    {
-        return new ProductResponse($this->getResource());
+    public function get(
+        ?string $include = null,
+        ?array $include_fields = null,
+        ?array $exclude_fields = null
+    ): ProductResponse {
+        $params = [];
+
+        if (!is_null($include)) {
+            $params[self::FILTER_INCLUDE] = $include;
+        }
+        if (!is_null($include_fields)) {
+            $params[self::FILTER_INCLUDE_FIELDS] = implode(',', $include_fields);
+            ;
+        }
+        if (!is_null($exclude_fields)) {
+            $params[self::FILTER_EXCLUDE_FIELDS] = implode(',', $exclude_fields);
+        }
+
+        return new ProductResponse($this->getResource($params));
     }
 
     public function getAll(array $filters = [], int $page = 1, int $limit = 250): ProductsResponse

--- a/src/BigCommerce/Api/Generic/GetResource.php
+++ b/src/BigCommerce/Api/Generic/GetResource.php
@@ -3,6 +3,7 @@
 namespace BigCommerce\ApiV3\Api\Generic;
 
 use BigCommerce\ApiV3\Client;
+use GuzzleHttp\RequestOptions;
 use Psr\Http\Message\ResponseInterface;
 
 trait GetResource
@@ -10,8 +11,13 @@ trait GetResource
     abstract public function singleResourceUrl(): string;
     abstract public function getClient(): Client;
 
-    protected function getResource(): ResponseInterface
+    protected function getResource(array $queryParams = []): ResponseInterface
     {
-        return $this->getClient()->getRestClient()->get($this->singleResourceUrl());
+        return $this->getClient()->getRestClient()->get(
+            $this->singleResourceUrl(),
+            [
+                RequestOptions::QUERY => $queryParams,
+            ]
+        );
     }
 }

--- a/tests/BigCommerce/Api/Catalog/ProductsApiTest.php
+++ b/tests/BigCommerce/Api/Catalog/ProductsApiTest.php
@@ -30,8 +30,9 @@ final class ProductsApiTest extends BigCommerceApiTest
     public function testCanGetProduct(): void
     {
         $this->setReturnData('catalog__products__174__get.json');
-        $productResponse = $this->getApi()->catalog()->product(174)->get();
+        $productResponse = $this->getApi()->catalog()->product(174)->get(null, ['weight', 'width']);
         $this->assertEquals(174, $productResponse->getProduct()->id);
+        $this->assertEquals('include_fields=weight%2Cwidth', $this->getLastRequest()->getUri()->getQuery());
     }
 
     public function testCanGetAllPagesForProducts(): void


### PR DESCRIPTION
Allow the use of [parameters in ProductsApi::Get](https://developer.bigcommerce.com/api-reference/store-management/catalog/products/getproductbyid).

Here's an example using PHP 8:

```php
$product = $api->catalog()->product(123)->get(include_fields: ['description', 'sku'])->getProduct();
```

Fixes #46 