### PR TITLE
fixed typo on ScriptsApi endpoint constants

### DIFF
--- a/src/BigCommerce/Api/Scripts/ScriptsApi.php
+++ b/src/BigCommerce/Api/Scripts/ScriptsApi.php
@@ -20,8 +20,8 @@ class ScriptsApi extends UuidResourceApi
     use UpdateResource;
     use CreateResource;
 
-    private const SCRIPT_ENDPOINT  = 'content/scripts';
-    private const SCRIPTS_ENDPOINT = 'content/scripts/%s';
+    private const SCRIPT_ENDPOINT  = 'content/scripts/%s';
+    private const SCRIPTS_ENDPOINT = 'content/scripts';
 
     public function get(): ScriptResponse
     {


### PR DESCRIPTION
`SCRIPT_ENDPOINT` and `SCRIPTS_ENDPOINT` were interchanged.


fixes #55 getting 404 on Scripts API