### PR TITLE
Fix/add missing create and update methods

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,3 +5,4 @@ Added missing create and update endpoints for:
  - ProductReviewsApi
  - ProductBulkPricingRulesApi
  - ProductVariantMetafieldsApi
+ - ProductOptionValuesApi

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,3 +4,4 @@ Added missing create and update endpoints for:
 
  - ProductReviewsApi
  - ProductBulkPricingRulesApi
+ - ProductVariantMetafieldsApi

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 Added missing create and update endpoints for:
 
- - ProductReviewsApi
- - ProductBulkPricingRulesApi
- - ProductVariantMetafieldsApi
- - ProductOptionValuesApi
+ - [ProductReviewsApi](https://aligent.github.io/bigcommerce-v3-api-php-client/classes/BigCommerce-ApiV3-Api-Catalog-Products-ProductReviewsApi.html)
+ - [ProductBulkPricingRulesApi](https://aligent.github.io/bigcommerce-v3-api-php-client/classes/BigCommerce-ApiV3-Api-Catalog-Products-ProductBulkPricingRulesApi.html)
+ - [ProductVariantMetafieldsApi](https://aligent.github.io/bigcommerce-v3-api-php-client/classes/BigCommerce-ApiV3-Api-Catalog-Products-ProductVariant-ProductVariantMetafieldsApi.html)
+ - [ProductOptionValuesApi](https://aligent.github.io/bigcommerce-v3-api-php-client/classes/BigCommerce-ApiV3-Api-Catalog-Products-ProductOption-ProductOptionValuesApi.html)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,8 @@
-### New Features
+### Fixes
 
-Implemented the [Redirects V3 API](https://developer.bigcommerce.com/api-reference/store-management/redirects/redirects/getredirects)
+Added missing create and update endpoints for:
+
+ - ProductReviewsApi
 
 
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,7 +3,4 @@
 Added missing create and update endpoints for:
 
  - ProductReviewsApi
-
-
-
-
+ - ProductBulkPricingRulesApi

--- a/src/BigCommerce/Api/Catalog/Products/ProductBulkPricingRulesApi.php
+++ b/src/BigCommerce/Api/Catalog/Products/ProductBulkPricingRulesApi.php
@@ -3,13 +3,14 @@
 namespace BigCommerce\ApiV3\Api\Catalog\Products;
 
 use BigCommerce\ApiV3\Api\Generic\ResourceApi;
+use BigCommerce\ApiV3\ResourceModels\Catalog\Product\ProductBulkPricingRule;
 use BigCommerce\ApiV3\ResponseModels\Product\ProductBulkPricingRuleResponse;
 use BigCommerce\ApiV3\ResponseModels\Product\ProductBulkPricingRulesResponse;
 
 class ProductBulkPricingRulesApi extends ResourceApi
 {
     public const RESOURCE_NAME = 'bulk-pricing-rules';
-    public const BULK_PRICING_RULE_ENDPOINT  = 'catalog/products/%d/bulk-pricing-rules/%d';
+    public const BULK_PRICING_RULE_ENDPOINT = 'catalog/products/%d/bulk-pricing-rules/%d';
     public const BULK_PRICING_RULES_ENDPOINT = 'catalog/products/%d/bulk-pricing-rules';
 
     protected function singleResourceEndpoint(): string
@@ -35,5 +36,15 @@ class ProductBulkPricingRulesApi extends ResourceApi
     public function getAll(array $filters = [], int $page = 1, int $limit = 250): ProductBulkPricingRulesResponse
     {
         return new ProductBulkPricingRulesResponse($this->getAllResources($filters, $page, $limit));
+    }
+
+    public function create(ProductBulkPricingRule $bulkPricingRule): ProductBulkPricingRuleResponse
+    {
+        return new ProductBulkPricingRuleResponse($this->createResource($bulkPricingRule));
+    }
+
+    public function update(ProductBulkPricingRule $bulkPricingRule): ProductBulkPricingRuleResponse
+    {
+        return new ProductBulkPricingRuleResponse($this->updateResource($bulkPricingRule));
     }
 }

--- a/src/BigCommerce/Api/Catalog/Products/ProductImagesApi.php
+++ b/src/BigCommerce/Api/Catalog/Products/ProductImagesApi.php
@@ -7,7 +7,7 @@ use BigCommerce\ApiV3\ResourceModels\Catalog\Product\ProductImage;
 use BigCommerce\ApiV3\ResponseModels\Product\ProductImageResponse;
 use BigCommerce\ApiV3\ResponseModels\Product\ProductImagesResponse;
 
-class ProductImagesApi extends ResourceApi
+class delaide team ProductImagesApi extends ResourceApi
 {
     public const RESOURCE_NAME   = 'images';
     public const IMAGES_ENDPOINT = 'catalog/products/%d/images';

--- a/src/BigCommerce/Api/Catalog/Products/ProductImagesApi.php
+++ b/src/BigCommerce/Api/Catalog/Products/ProductImagesApi.php
@@ -7,7 +7,7 @@ use BigCommerce\ApiV3\ResourceModels\Catalog\Product\ProductImage;
 use BigCommerce\ApiV3\ResponseModels\Product\ProductImageResponse;
 use BigCommerce\ApiV3\ResponseModels\Product\ProductImagesResponse;
 
-class delaide team ProductImagesApi extends ResourceApi
+class ProductImagesApi extends ResourceApi
 {
     public const RESOURCE_NAME   = 'images';
     public const IMAGES_ENDPOINT = 'catalog/products/%d/images';

--- a/src/BigCommerce/Api/Catalog/Products/ProductOption/ProductOptionValuesApi.php
+++ b/src/BigCommerce/Api/Catalog/Products/ProductOption/ProductOptionValuesApi.php
@@ -3,6 +3,7 @@
 namespace BigCommerce\ApiV3\Api\Catalog\Products\ProductOption;
 
 use BigCommerce\ApiV3\Api\Generic\ResourceApi;
+use BigCommerce\ApiV3\ResourceModels\Catalog\Product\ProductOptionValue;
 use BigCommerce\ApiV3\ResponseModels\Product\ProductOptionValueResponse;
 use BigCommerce\ApiV3\ResponseModels\Product\ProductOptionValuesResponse;
 
@@ -10,9 +11,9 @@ class ProductOptionValuesApi extends ResourceApi
 {
     private int $productId;
 
-    public const RESOURCE_NAME   = 'values';
+    public const RESOURCE_NAME = 'values';
     public const VALUES_ENDPOINT = 'catalog/products/%d/options/%d/values';
-    public const VALUE_ENDPOINT  = 'catalog/products/%d/options/%d/values/%d';
+    public const VALUE_ENDPOINT = 'catalog/products/%d/options/%d/values/%d';
 
     public function setProductId(int $productId): void
     {
@@ -66,5 +67,15 @@ class ProductOptionValuesApi extends ResourceApi
     public function getAll(array $filters = [], int $page = 1, int $limit = 250): ProductOptionValuesResponse
     {
         return new ProductOptionValuesResponse($this->getAllResources($filters, $page, $limit));
+    }
+
+    public function create(ProductOptionValue $optionValue): ProductOptionValueResponse
+    {
+        return new ProductOptionValueResponse($this->createResource($optionValue));
+    }
+
+    public function update(ProductOptionValue $optionValue): ProductOptionValueResponse
+    {
+        return new ProductOptionValueResponse($this->updateResource($optionValue));
     }
 }

--- a/src/BigCommerce/Api/Catalog/Products/ProductReviewsApi.php
+++ b/src/BigCommerce/Api/Catalog/Products/ProductReviewsApi.php
@@ -3,6 +3,7 @@
 namespace BigCommerce\ApiV3\Api\Catalog\Products;
 
 use BigCommerce\ApiV3\Api\Generic\ResourceApi;
+use BigCommerce\ApiV3\ResourceModels\Catalog\Product\ProductReview;
 use BigCommerce\ApiV3\ResponseModels\PaginatedResponse;
 use BigCommerce\ApiV3\ResponseModels\Product\ProductReviewResponse;
 use BigCommerce\ApiV3\ResponseModels\Product\ProductReviewsResponse;
@@ -10,9 +11,9 @@ use BigCommerce\ApiV3\ResponseModels\SingleResourceResponse;
 
 class ProductReviewsApi extends ResourceApi
 {
-    public const RESOURCE_NAME     = 'reviews';
-    public const REVIEW_ENDPOINT   = 'catalog/products/%s/reviews/%s';
-    public const REVIEWS_ENDPOINT  = 'catalog/products/%s/reviews';
+    public const RESOURCE_NAME = 'reviews';
+    public const REVIEW_ENDPOINT = 'catalog/products/%s/reviews/%s';
+    public const REVIEWS_ENDPOINT = 'catalog/products/%s/reviews';
 
     protected function singleResourceEndpoint(): string
     {
@@ -37,5 +38,15 @@ class ProductReviewsApi extends ResourceApi
     public function getAll(array $filters = [], int $page = 1, int $limit = 250): ProductReviewsResponse
     {
         return new ProductReviewsResponse($this->getAllResources($filters, $page, $limit));
+    }
+
+    public function create(ProductReview $review): ProductReviewResponse
+    {
+        return new ProductReviewResponse($this->createResource($review));
+    }
+
+    public function update(ProductReview $review): ProductReviewResponse
+    {
+        return new ProductReviewResponse($this->updateResource($review));
     }
 }

--- a/src/BigCommerce/Api/Catalog/Products/ProductVariant/ProductVariantMetafieldsApi.php
+++ b/src/BigCommerce/Api/Catalog/Products/ProductVariant/ProductVariantMetafieldsApi.php
@@ -71,6 +71,7 @@ class ProductVariantMetafieldsApi extends ResourceApi
 
     public function create(ProductVariantMetafield $metafield): ProductVariantMetafieldResponse
     {
+        $metafield->resource_id = $this->getParentResourceId() ?? 0;
         return new ProductVariantMetafieldResponse($this->createResource($metafield));
     }
 

--- a/src/BigCommerce/Api/Catalog/Products/ProductVariant/ProductVariantMetafieldsApi.php
+++ b/src/BigCommerce/Api/Catalog/Products/ProductVariant/ProductVariantMetafieldsApi.php
@@ -3,6 +3,7 @@
 namespace BigCommerce\ApiV3\Api\Catalog\Products\ProductVariant;
 
 use BigCommerce\ApiV3\Api\Generic\ResourceApi;
+use BigCommerce\ApiV3\ResourceModels\Catalog\Product\ProductVariantMetafield;
 use BigCommerce\ApiV3\ResponseModels\Product\ProductVariantMetafieldResponse;
 use BigCommerce\ApiV3\ResponseModels\Product\ProductVariantMetafieldsResponse;
 
@@ -11,7 +12,7 @@ class ProductVariantMetafieldsApi extends ResourceApi
     private int $productId;
 
     private const RESOURCE_NAME = 'metafields';
-    private const METAFIELD_ENDPOINT  = 'catalog/product/%d/variants/%d/metafields/%d';
+    private const METAFIELD_ENDPOINT = 'catalog/product/%d/variants/%d/metafields/%d';
     private const METAFIELDS_ENDPOINT = 'catalog/product/%d/variants/%d/metafields';
 
     public function getProductId(): int
@@ -66,5 +67,15 @@ class ProductVariantMetafieldsApi extends ResourceApi
     public function getAll(array $filters = [], int $page = 1, int $limit = 250): ProductVariantMetafieldsResponse
     {
         return new ProductVariantMetafieldsResponse($this->getAllResources($filters, $page, $limit));
+    }
+
+    public function create(ProductVariantMetafield $metafield): ProductVariantMetafieldResponse
+    {
+        return new ProductVariantMetafieldResponse($this->createResource($metafield));
+    }
+
+    public function update(ProductVariantMetafield $metafield): ProductVariantMetafieldResponse
+    {
+        return new ProductVariantMetafieldResponse($this->updateResource($metafield));
     }
 }


### PR DESCRIPTION
Added missing create and update endpoints for:

 - [ProductReviewsApi](https://aligent.github.io/bigcommerce-v3-api-php-client/classes/BigCommerce-ApiV3-Api-Catalog-Products-ProductReviewsApi.html)
 - [ProductBulkPricingRulesApi](https://aligent.github.io/bigcommerce-v3-api-php-client/classes/BigCommerce-ApiV3-Api-Catalog-Products-ProductBulkPricingRulesApi.html)
 - [ProductVariantMetafieldsApi](https://aligent.github.io/bigcommerce-v3-api-php-client/classes/BigCommerce-ApiV3-Api-Catalog-Products-ProductVariant-ProductVariantMetafieldsApi.html)
 - [ProductOptionValuesApi](https://aligent.github.io/bigcommerce-v3-api-php-client/classes/BigCommerce-ApiV3-Api-Catalog-Products-ProductOption-ProductOptionValuesApi.html)
