### PR TITLE
Add redirect convenience method for products and categories

### DIFF
--- a/src/BigCommerce/ResourceModels/Redirect/Redirect.php
+++ b/src/BigCommerce/ResourceModels/Redirect/Redirect.php
@@ -42,11 +42,11 @@ class Redirect extends ResourceModel
 
     public function toProduct(int $productId): void
     {
-        $this->to = RedirectTo::Build(RedirectTo::TYPE__PRODUCT, $productId);
+        $this->to = RedirectTo::buildRedirectTo(RedirectTo::TYPE__PRODUCT, $productId);
     }
 
     public function toCategory(int $categoryId): void
     {
-        $this->to = RedirectTo::Build(RedirectTo::TYPE__CATEGORY, $categoryId);
+        $this->to = RedirectTo::buildRedirectTo(RedirectTo::TYPE__CATEGORY, $categoryId);
     }
 }

--- a/src/BigCommerce/ResourceModels/Redirect/Redirect.php
+++ b/src/BigCommerce/ResourceModels/Redirect/Redirect.php
@@ -5,6 +5,25 @@ namespace BigCommerce\ApiV3\ResourceModels\Redirect;
 use BigCommerce\ApiV3\ResourceModels\ResourceModel;
 use stdClass;
 
+/**
+ * Redirect Resource
+ *
+ * Represents the request object for redirect objects.
+ *
+ * Contains a convenience method for simply redirecting to a product or category
+ *
+ * ```php
+ * $api = new BigCommerce\ApiV3\Client($_ENV['hash'], $_ENV['CLIENT_ID'], $_ENV['ACCESS_TOKEN']);
+ *
+ * $productRedirect = new Redirect();
+ * $productRedirect->site_id = 1000;
+ * $productRedirect->from_path = '/cool-product.html';
+ * $productRedirect->toProduct(123);
+ *
+ * $api->redirects()->upsert([$productRedirect]);
+ * ```
+ *
+ */
 class Redirect extends ResourceModel
 {
     public string $from_path;
@@ -19,5 +38,15 @@ class Redirect extends ResourceModel
         }
 
         parent::__construct($optionObject);
+    }
+
+    public function toProduct(int $productId): void
+    {
+        $this->to = RedirectTo::Build(RedirectTo::TYPE__PRODUCT, $productId);
+    }
+
+    public function toCategory(int $categoryId): void
+    {
+        $this->to = RedirectTo::Build(RedirectTo::TYPE__CATEGORY, $categoryId);
     }
 }

--- a/src/BigCommerce/ResourceModels/Redirect/RedirectTo.php
+++ b/src/BigCommerce/ResourceModels/Redirect/RedirectTo.php
@@ -17,7 +17,7 @@ class RedirectTo extends ResourceModel
     public ?int $entity_id;
     public ?string $url;
 
-    public static function Build(string $type, ?int $entityId = null, ?string $url = null): RedirectTo
+    public static function buildRedirectTo(string $type, ?int $entityId = null, ?string $url = null): RedirectTo
     {
         $redirectTo = new self();
         $redirectTo->type = $type;

--- a/src/BigCommerce/ResourceModels/Redirect/RedirectTo.php
+++ b/src/BigCommerce/ResourceModels/Redirect/RedirectTo.php
@@ -15,5 +15,15 @@ class RedirectTo extends ResourceModel
 
     public string $type;
     public ?int $entity_id;
-    public string $url;
+    public ?string $url;
+
+    public static function Build(string $type, ?int $entityId = null, ?string $url = null): RedirectTo
+    {
+        $redirectTo = new self();
+        $redirectTo->type = $type;
+        $redirectTo->entity_id = $entityId;
+        $redirectTo->url = $url;
+
+        return $redirectTo;
+    }
 }

--- a/tests/BigCommerce/Api/Redirects/RedirectsApiTest.php
+++ b/tests/BigCommerce/Api/Redirects/RedirectsApiTest.php
@@ -14,10 +14,10 @@ class RedirectsApiTest extends BigCommerceApiTest
         $redirect = new Redirect();
         $redirect->from_path = '/old-url';
         $redirect->site_id = 0;
-        $redirect->to = new RedirectTo();
-        $redirect->to->type = RedirectTo::TYPE__PRODUCT;
-        $redirect->to->entity_id = 0;
-        $redirect->to->url = '/new-url';
+        $redirect->toProduct(1);
+
+        $this->assertEquals(RedirectTo::TYPE__PRODUCT, $redirect->to->type);
+        $this->assertEquals(1, $redirect->to->entity_id);
 
         $this->getApi()->redirects()->upsert([$redirect]);
         $this->assertEquals('storefront/redirects', $this->getLastRequestPath());


### PR DESCRIPTION
Adding redirect targets was a bit long and annoying, so I made a simple version

### Previously...

```php
$redirect = new Redirect();
$redirect->from_path = "/old-url/$i";
$redirect->site_id   = 0;

$redirectTo = new RedirectTo();
$redirectTo->type      = RedirectTo::TYPE__PRODUCT;
$redirectTo->entity_id = 123;

$redirect->to = redirectTo;
```

### Now...

```php
$redirect = new Redirect();
$redirect->from_path = "/old-url/$i";
$redirect->site_id   = 0;
$redirect->toProduct(123);
```