### PR TITLE
Update the batch update resource method to allow for retries

### DIFF
--- a/src/BigCommerce/Api/Generic/BatchUpdateResource.php
+++ b/src/BigCommerce/Api/Generic/BatchUpdateResource.php
@@ -4,14 +4,19 @@ namespace BigCommerce\ApiV3\Api\Generic;
 
 use BigCommerce\ApiV3\Client;
 use BigCommerce\ApiV3\ResponseModels\PaginatedResponse;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\RequestOptions;
+use Psr\Http\Client\RequestExceptionInterface;
 use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
 
 trait BatchUpdateResource
 {
     abstract public function batchUpdate(array $resources): PaginatedResponse;
     abstract protected function multipleResourcesEndpoint(): string;
     abstract public function getClient(): Client;
+
+    private int $maxRetries = 0;
 
     protected function maxBatchSize(): int
     {
@@ -21,20 +26,46 @@ trait BatchUpdateResource
     /**
      * @param array $resources
      * @return ResponseInterface[]
+     * @throws RequestExceptionInterface
      */
     protected function batchUpdateResource(array $resources): array
     {
         $chunks = array_chunk($resources, $this->maxBatchSize());
-        $responses = [];
-        foreach ($chunks as $chunk) {
-            $responses[] = $this->getClient()->getRestClient()->put(
-                $this->multipleResourcesEndpoint(),
-                [
-                    RequestOptions::JSON => $chunk,
-                ]
-            );
-        }
+        return array_map(fn($chunk) => $this->putRequestWithRetries($chunk), $chunks);
+    }
 
-        return $responses;
+    private function putRequestWithRetries($data): ResponseInterface
+    {
+        $retriesRemaining = $this->getMaxRetries() + 1;
+
+        while ($retriesRemaining-- > 0) {
+            try {
+                return $this->getClient()->getRestClient()->put(
+                    $this->multipleResourcesEndpoint(),
+                    [
+                        RequestOptions::JSON => $data,
+                    ]
+                );
+            } catch (\Exception $exception) {
+                if (!in_array($exception->getCode(), $this->retryOnErrorCodes()) || $retriesRemaining <= 0) {
+                    throw $exception;
+                }
+            }
+        }
+    }
+
+    protected function retryOnErrorCodes(): array
+    {
+        return [500, 502, 503, 504];
+    }
+
+    public function getMaxRetries(): int
+    {
+        return $this->maxRetries;
+    }
+
+    public function setMaxRetries(int $maxRetries): void
+    {
+        $this->maxRetries = $maxRetries;
     }
 }

--- a/tests/BigCommerce/Api/Redirects/RedirectsApiTest.php
+++ b/tests/BigCommerce/Api/Redirects/RedirectsApiTest.php
@@ -5,6 +5,7 @@ namespace BigCommerce\Tests\Api\Redirects;
 use BigCommerce\ApiV3\ResourceModels\Redirect\Redirect;
 use BigCommerce\ApiV3\ResourceModels\Redirect\RedirectTo;
 use BigCommerce\Tests\BigCommerceApiTest;
+use GuzzleHttp\Exception\RequestException;
 
 class RedirectsApiTest extends BigCommerceApiTest
 {
@@ -37,5 +38,24 @@ class RedirectsApiTest extends BigCommerceApiTest
         $this->setReturnData('blank.json', 204);
         $this->getApi()->redirects()->delete([1, 2, 3]);
         $this->assertEquals('storefront/redirects', $this->getLastRequestPath());
+    }
+
+    public function testRetryOnError()
+    {
+        $this->setReturnData('blank.json', 503, [], 3);
+        $redirect = new Redirect();
+        $redirect->from_path = '/old-url';
+        $redirect->site_id = 0;
+        $redirect->toProduct(1);
+
+        //https://httpbin.org/status/502
+        $redirectsApi = $this->getApi()->redirects();
+        $redirectsApi->setMaxRetries(2);
+        try {
+            $redirectsApi->upsert([$redirect]);
+            $this->assertFalse(true, 'Exception not raised');
+        } catch (RequestException $e) {
+            $this->assertCount(3, $this->getRequestHistory());
+        }
     }
 }

--- a/tests/BigCommerce/BigCommerceApiTest.php
+++ b/tests/BigCommerce/BigCommerceApiTest.php
@@ -37,11 +37,14 @@ abstract class BigCommerceApiTest extends TestCase
         );
     }
 
-    protected function setReturnData(string $filename, int $statusCode = 200, array $headers = []): void
+    protected function setReturnData(string $filename, int $statusCode = 200, array $headers = [], int $numberOfResponses = 1): void
     {
-        $mock = new MockHandler([
-            new Response($statusCode, $headers, file_get_contents(self::RESPONSES_PATH . $filename)),
-        ]);
+        $responses = [];
+        for ($i = 1; $i <= $numberOfResponses; $i++) {
+            $responses[] = new Response($statusCode, $headers, file_get_contents(self::RESPONSES_PATH . $filename));
+        }
+
+        $mock = new MockHandler($responses);
 
         $handlerStack = HandlerStack::create($mock);
         $handlerStack->push(Middleware::history($this->container));

--- a/tests/BigCommerce/BigCommerceApiTest.php
+++ b/tests/BigCommerce/BigCommerceApiTest.php
@@ -37,8 +37,12 @@ abstract class BigCommerceApiTest extends TestCase
         );
     }
 
-    protected function setReturnData(string $filename, int $statusCode = 200, array $headers = [], int $numberOfResponses = 1): void
-    {
+    protected function setReturnData(
+        string $filename,
+        int $statusCode = 200,
+        array $headers = [],
+        int $numberOfResponses = 1
+    ): void {
         $responses = [];
         for ($i = 1; $i <= $numberOfResponses; $i++) {
             $responses[] = new Response($statusCode, $headers, file_get_contents(self::RESPONSES_PATH . $filename));


### PR DESCRIPTION
I'm having a lot of issues with large upserts at the moment, this should help!

The batch update endpoint will now retry each chunk up to the specified maximum number of times, for specific error codes (ie. not bad requests). It will then throw the exception as per normal.