### PR TITLE
Ability to fetch all customers at once

### DIFF
--- a/src/BigCommerce/Api/Customers/CustomersApi.php
+++ b/src/BigCommerce/Api/Customers/CustomersApi.php
@@ -22,6 +22,13 @@ class CustomersApi extends CustomerApiBase
         return new CustomersResponse($this->getAllResources($filters, $page, $limit));
     }
 
+    public function getAllPages(array $filter = []): CustomersResponse
+    {
+        return CustomersResponse::buildFromAllPages(function ($page) use ($filter) {
+            return $this->getAllResources($filter, $page, 200);
+        });
+    }
+
     public function getByEmail(string $email): ?Customer
     {
         $customers = $this->getAll([self::FILTER__EMAIL_IN => $email])->getCustomers();

--- a/src/BigCommerce/ResponseModels/Customer/CustomersResponse.php
+++ b/src/BigCommerce/ResponseModels/Customer/CustomersResponse.php
@@ -3,10 +3,9 @@
 namespace BigCommerce\ApiV3\ResponseModels\Customer;
 
 use BigCommerce\ApiV3\ResourceModels\Customer\Customer;
-use BigCommerce\ApiV3\ResponseModels\PaginatedResponse;
-use stdClass;
+use BigCommerce\ApiV3\ResponseModels\PaginatedBatchableResponse;
 
-class CustomersResponse extends PaginatedResponse
+class CustomersResponse extends PaginatedBatchableResponse
 {
     /**
      * @return Customer[]

--- a/tests/BigCommerce/Api/Customers/CustomersApiTest.php
+++ b/tests/BigCommerce/Api/Customers/CustomersApiTest.php
@@ -21,6 +21,15 @@ class CustomersApiTest extends BigCommerceApiTest
         $this->assertEquals('California', $customers[0]->addresses[0]->state_or_province);
     }
 
+    public function testCanGetAllPagesOfCustomers()
+    {
+        $this->setReturnData('customers__get_all.json');
+
+        $customersResponse = $this->getApi()->customers()->getAll();
+
+        $this->assertEquals(1, $customersResponse->getPagination()->total);
+    }
+
     public function testCanGetCustomerByEmail()
     {
         $this->setReturnData('customers__get_all.json');


### PR DESCRIPTION
Implements `CustomersApi::getAllPages()`, which works identically to `ProductsApi::getAllPages()`, allowing all the of the customers to be downloaded in one call. This will make as many requests as is required to fetch them all.