### PR TITLE
fix - fix class namespace to respect PSR-4

### DIFF
--- a/tests/BigCommerce/Api/CustomTemplateAssociations/CustomTemplateAssociationsApiTest.php
+++ b/tests/BigCommerce/Api/CustomTemplateAssociations/CustomTemplateAssociationsApiTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BigCommerce\Tests\Api\CustomTemplateAssociation;
+namespace BigCommerce\Tests\Api\CustomTemplateAssociations;
 
 use BigCommerce\ApiV3\Api\CustomTemplateAssociations\CustomTemplateAssociationsApi;
 use BigCommerce\ApiV3\ResourceModels\CustomTemplateAssociation\CustomTemplateAssociation;


### PR DESCRIPTION
Installing the dependency raised warning on autoloading generation: 

```
Generating optimized autoload files
Class BigCommerce\Tests\Api\CustomTemplateAssociation\CustomTemplateAssociationsApiTest located in ./vendor/aligent/bigcommerce-api-client/tests/BigCommerce/Api/CustomTemplateAssociations/CustomTemplateAssociationsApiTest.php does not comply with psr-4 autoloading standard. Skipping.
```
