### PR TITLE
Feature/phpcs with annotations

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -38,4 +38,6 @@ jobs:
       run: composer run-script test
 
     - name: Run linter to check code style
-      run: composer run-script check-style
+      uses: chekalsky/phpcs-action@v1
+      with:
+        enable_warnings: true

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
+    <description>Coding standard configuration for the Bigcommerce V3 API Client.</description>
+
+    <file>src</file>
+    <file>tests</file>
+
+    <rule  ref="PSR12"/>
+</ruleset>

--- a/src/BigCommerce/Api/Catalog/BrandsApi.php
+++ b/src/BigCommerce/Api/Catalog/BrandsApi.php
@@ -33,6 +33,7 @@ class BrandsApi extends ResourceApi
     private const BRAND_ENDPOINT  = 'catalog/brands/%d';
     private const BRANDS_ENDPOINT = 'catalog/brands';
 
+    public const DO_NOT_MERGE = "this because it's only to test the new phpcs github action with annotations. This line is clearly too long.";
     public const FILTER_INCLUDE_FIELDS = 'include_fields';
     public const FILTER_EXCLUDE_FIELDS = 'exclude_fields';
 

--- a/src/BigCommerce/Api/Catalog/BrandsApi.php
+++ b/src/BigCommerce/Api/Catalog/BrandsApi.php
@@ -33,7 +33,6 @@ class BrandsApi extends ResourceApi
     private const BRAND_ENDPOINT  = 'catalog/brands/%d';
     private const BRANDS_ENDPOINT = 'catalog/brands';
 
-    public const DO_NOT_MERGE = "this because it's only to test the new phpcs github action with annotations. This line is clearly too long.";
     public const FILTER_INCLUDE_FIELDS = 'include_fields';
     public const FILTER_EXCLUDE_FIELDS = 'exclude_fields';
 


### PR DESCRIPTION

Add GitHub annotations to PHPCS errors. Example: https://github.com/aligent/bigcommerce-v3-api-php-client/pull/105

![image (1)](https://user-images.githubusercontent.com/641652/143988769-02f24f79-d06f-4aab-8c62-449ceb661ba5.png)

