### PR TITLE
Undefined index within customer getByEmail method

### DIFF
--- a/src/BigCommerce/Api/Customers/CustomersApi.php
+++ b/src/BigCommerce/Api/Customers/CustomersApi.php
@@ -33,7 +33,7 @@ class CustomersApi extends CustomerApiBase
     {
         $customers = $this->getAll([self::FILTER__EMAIL_IN => $email])->getCustomers();
 
-        if (!$customers[0]) {
+        if (count($customers) === 0) {
             return null;
         } elseif (count($customers) > 1) {
             throw new UnexpectedValueException("There are more than one customer with the email address $email");

--- a/tests/BigCommerce/Api/Customers/CustomersApiTest.php
+++ b/tests/BigCommerce/Api/Customers/CustomersApiTest.php
@@ -38,6 +38,14 @@ class CustomersApiTest extends BigCommerceApiTest
         $this->assertEquals('John', $customer->first_name);
     }
 
+    public function testUnknownCustomerReturnsEmptyResult()
+    {
+        $this->setReturnData('customers__get_all_no_results.json');
+        $customer = $this->getApi()->customers()->getByEmail('wade.wilson@spam.me');
+
+        $this->assertNull($customer);
+    }
+
     public function testCanGetCustomerById()
     {
         $this->setReturnData('customers__get_all.json');


### PR DESCRIPTION
Fixes an issue where certain versions of PHP would throw an error $cu…stomers variable was an empty array, thus the index of 0 would not exist.