### PR TITLE
Fix/135 missing config values

### DIFF
--- a/src/BigCommerce/ResourceModels/Catalog/Product/ProductModifier.php
+++ b/src/BigCommerce/ResourceModels/Catalog/Product/ProductModifier.php
@@ -30,11 +30,7 @@ class ProductModifier extends ResourceModel
             !is_null($optionObject) && !empty($optionObject->config)
             && get_class($optionObject->config) !== ProductModifierConfig::class
         ) {
-            $this->config = new ProductModifierConfig(
-                $optionObject->config->product_list_adjusts_inventory,
-                $optionObject->config->product_list_adjusts_pricing,
-                $optionObject->config->product_list_shipping_calc
-            );
+            $this->config = new ProductModifierConfig($optionObject->config);
         }
 
         if (!is_null($optionObject) && isset($optionObject->config)) {

--- a/src/BigCommerce/ResourceModels/Catalog/Product/ProductModifierConfig.php
+++ b/src/BigCommerce/ResourceModels/Catalog/Product/ProductModifierConfig.php
@@ -2,21 +2,41 @@
 
 namespace BigCommerce\ApiV3\ResourceModels\Catalog\Product;
 
-class ProductModifierConfig
+use BigCommerce\ApiV3\ResourceModels\ResourceModel;
+
+class ProductModifierConfig extends ResourceModel
 {
-    public const PRODUCT_LIST_SHIPPING_BY_WEIGHT = 'weight';
+    public const PRODUCT_LIST_SHIPPING_NONE       = 'none';
+    public const PRODUCT_LIST_SHIPPING_BY_WEIGHT  = 'weight';
+    public const PRODUCT_LIST_SHIPPING_BY_PACKAGE = 'package';
 
-    public bool $product_list_adjusts_inventory;
-    public bool $product_list_adjusts_pricing;
-    public string $product_list_shipping_calc;
+    public ?string $default_value;
+    public ?bool $checked_by_default;
+    public ?string $checkbox_label;
 
-    public function __construct(
-        bool $product_list_adjusts_inventory,
-        bool $product_list_adjusts_pricing,
-        string $product_list_shipping_calc
-    ) {
-        $this->product_list_adjusts_inventory = $product_list_adjusts_inventory;
-        $this->product_list_adjusts_pricing = $product_list_adjusts_pricing;
-        $this->product_list_shipping_calc = $product_list_shipping_calc;
-    }
+    public ?bool $date_limited;
+    public ?string $date_limit_mode;
+    public ?string $date_earliest_value;
+    public ?string $date_latest_value;
+
+    public ?string $file_types_mode;
+    public ?array $file_types_supported;
+    public ?array $file_types_other;
+    public ?string $file_max_size;
+
+    public ?bool $text_characters_limited;
+    public ?int $text_min_length;
+    public ?int $text_max_length;
+    public ?bool $text_lines_limited;
+    public ?int $text_max_lines;
+
+    public ?bool $number_limited;
+    public ?string $number_limit_mode;
+    public ?float $number_lowest_value;
+    public ?float $number_highest_value;
+    public ?bool $number_integers_only;
+
+    public ?bool $product_list_adjusts_inventory;
+    public ?bool $product_list_adjusts_pricing;
+    public ?string $product_list_shipping_calc;
 }

--- a/src/BigCommerce/ResourceModels/Catalog/Product/ProductModifierConfig.php
+++ b/src/BigCommerce/ResourceModels/Catalog/Product/ProductModifierConfig.php
@@ -22,7 +22,7 @@ class ProductModifierConfig extends ResourceModel
     public ?string $file_types_mode;
     public ?array $file_types_supported;
     public ?array $file_types_other;
-    public ?string $file_max_size;
+    public ?int $file_max_size;
 
     public ?bool $text_characters_limited;
     public ?int $text_min_length;

--- a/tests/BigCommerce/Api/Catalog/Products/ModifiersApiTest.php
+++ b/tests/BigCommerce/Api/Catalog/Products/ModifiersApiTest.php
@@ -2,6 +2,7 @@
 
 namespace BigCommerce\Tests\Api\Catalog\Products;
 
+use BigCommerce\ApiV3\ResourceModels\Catalog\Product\ProductModifierConfig;
 use BigCommerce\Tests\BigCommerceApiTest;
 
 class ModifiersApiTest extends BigCommerceApiTest
@@ -26,6 +27,47 @@ class ModifiersApiTest extends BigCommerceApiTest
         $this->assertEquals('earliest', $modifiers[5]->config->date_limit_mode);
         $this->assertEquals(['images'], $modifiers[6]->config->file_types_supported);
         $this->assertEquals(20, $modifiers[7]->config->text_max_lines);
-        $this->markTestIncomplete();
+    }
+
+    public function testCanUpdateModifierConfigs(): void
+    {
+        $textConfig = new ProductModifierConfig((object)[
+            "default_value"   => "",
+            "text_characters_limited" => false,
+            "text_min_length" => 0,
+            "text_max_length" => 0
+        ]);
+
+        $dateConfig =  new ProductModifierConfig((object)[
+            "date_limited"      => false,
+            "date_limit_mode"   => "earliest",
+            "date_earliest_value" => null,
+            "date_latest_value" => null,
+            "default_value"     => "2022-06-01T00:00:00+00:00"
+        ]);
+
+        $fileConfig =  new ProductModifierConfig((object)[
+            "file_types_mode" => "specific",
+            "file_types_supported" => [
+                "images"
+            ],
+            "file_types_other" => [],
+            "file_max_size" => 524288
+        ]);
+
+        $this->assertEquals(
+            '{"default_value":"","text_characters_limited":false,"text_min_length":0,"text_max_length":0}',
+            json_encode($textConfig)
+        );
+
+        $this->assertEquals(
+            '{"default_value":"2022-06-01T00:00:00+00:00","date_limited":false,"date_limit_mode":"earliest"}',
+            json_encode($dateConfig)
+        );
+
+        $this->assertEquals(
+            '{"file_types_mode":"specific","file_types_supported":["images"],"file_types_other":[],"file_max_size":524288}',
+            json_encode($fileConfig)
+        );
     }
 }

--- a/tests/BigCommerce/Api/Catalog/Products/ModifiersApiTest.php
+++ b/tests/BigCommerce/Api/Catalog/Products/ModifiersApiTest.php
@@ -18,6 +18,14 @@ class ModifiersApiTest extends BigCommerceApiTest
 
     public function testCanGetAllModifiers(): void
     {
+        $this->setReturnData('catalog__products__modifiers__6962__values__get_all.json');
+
+        $modifiers = $this->getApi()->catalog()->product(6962)->modifiers()->getAll()->getProductModifiers();
+
+        $this->assertCount(8, $modifiers);
+        $this->assertEquals('earliest', $modifiers[5]->config->date_limit_mode);
+        $this->assertEquals(['images'], $modifiers[6]->config->file_types_supported);
+        $this->assertEquals(20, $modifiers[7]->config->text_max_lines);
         $this->markTestIncomplete();
     }
 }

--- a/tests/BigCommerce/Api/Catalog/Products/ModifiersApiTest.php
+++ b/tests/BigCommerce/Api/Catalog/Products/ModifiersApiTest.php
@@ -66,7 +66,8 @@ class ModifiersApiTest extends BigCommerceApiTest
         );
 
         $this->assertEquals(
-            '{"file_types_mode":"specific","file_types_supported":["images"],"file_types_other":[],"file_max_size":524288}',
+            '{"file_types_mode":"specific","file_types_supported":["images"],' .
+            '"file_types_other":[],"file_max_size":524288}',
             json_encode($fileConfig)
         );
     }

--- a/tests/BigCommerce/responses/catalog__products__modifiers__6962__values__get_all.json
+++ b/tests/BigCommerce/responses/catalog__products__modifiers__6962__values__get_all.json
@@ -212,12 +212,48 @@
         "default_value": "2022-06-01T00:00:00+00:00"
       },
       "option_values": []
+    },
+    {
+      "id": 119,
+      "product_id": 6962,
+      "name": "File1654474739-6962",
+      "display_name": "File",
+      "type": "file",
+      "required": false,
+      "sort_order": 9,
+      "config": {
+        "file_types_mode": "specific",
+        "file_types_supported": [
+          "images"
+        ],
+        "file_types_other": [],
+        "file_max_size": 524288
+      },
+      "option_values": []
+    },
+    {
+      "id": 120,
+      "product_id": 6962,
+      "name": "Big-Text1654474739-6962",
+      "display_name": "Big Text",
+      "type": "multi_line_text",
+      "required": false,
+      "sort_order": 9,
+      "config": {
+        "default_value": "",
+        "text_characters_limited": false,
+        "text_min_length": 0,
+        "text_max_length": 0,
+        "text_lines_limited": true,
+        "text_max_lines": 20
+      },
+      "option_values": []
     }
   ],
   "meta": {
     "pagination": {
-      "total": 6,
-      "count": 6,
+      "total": 8,
+      "count": 8,
       "per_page": 50,
       "current_page": 1,
       "total_pages": 1,

--- a/tests/BigCommerce/responses/catalog__products__modifiers__6962__values__get_all.json
+++ b/tests/BigCommerce/responses/catalog__products__modifiers__6962__values__get_all.json
@@ -1,0 +1,229 @@
+{
+  "data": [
+    {
+      "id": 113,
+      "product_id": 6962,
+      "name": "Custom-Message1654474736-6962",
+      "display_name": "Custom Message",
+      "type": "text",
+      "required": true,
+      "sort_order": 5,
+      "config": {
+        "default_value": "",
+        "text_characters_limited": false,
+        "text_min_length": 0,
+        "text_max_length": 0
+      },
+      "option_values": []
+    },
+    {
+      "id": 114,
+      "product_id": 6962,
+      "name": "Include-Insurance?1654474736-6962",
+      "display_name": "Include Insurance?",
+      "type": "checkbox",
+      "required": false,
+      "sort_order": 6,
+      "config": {
+        "checkbox_label": "",
+        "checked_by_default": true
+      },
+      "option_values": [
+        {
+          "id": 98,
+          "option_id": 114,
+          "label": "Yes",
+          "sort_order": 0,
+          "value_data": {
+            "checked_value": true
+          },
+          "is_default": true,
+          "adjusters": {
+            "price": null,
+            "weight": null,
+            "image_url": "",
+            "purchasing_disabled": {
+              "status": false,
+              "message": ""
+            }
+          }
+        },
+        {
+          "id": 99,
+          "option_id": 114,
+          "label": "No",
+          "sort_order": 1,
+          "value_data": {
+            "checked_value": false
+          },
+          "is_default": false,
+          "adjusters": {
+            "price": null,
+            "weight": null,
+            "image_url": "",
+            "purchasing_disabled": {
+              "status": false,
+              "message": ""
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 115,
+      "product_id": 6962,
+      "name": "List1654474737-6962",
+      "display_name": "List",
+      "type": "radio_buttons",
+      "required": true,
+      "sort_order": 7,
+      "config": [],
+      "option_values": [
+        {
+          "id": 100,
+          "option_id": 115,
+          "label": "1",
+          "sort_order": 0,
+          "value_data": null,
+          "is_default": false,
+          "adjusters": {
+            "price": null,
+            "weight": null,
+            "image_url": "",
+            "purchasing_disabled": {
+              "status": false,
+              "message": ""
+            }
+          }
+        },
+        {
+          "id": 101,
+          "option_id": 115,
+          "label": "2",
+          "sort_order": 1,
+          "value_data": null,
+          "is_default": false,
+          "adjusters": {
+            "price": null,
+            "weight": null,
+            "image_url": "",
+            "purchasing_disabled": {
+              "status": false,
+              "message": ""
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 116,
+      "product_id": 6962,
+      "name": "Products1654474737-6962",
+      "display_name": "Products",
+      "type": "product_list_with_images",
+      "required": false,
+      "sort_order": 8,
+      "config": {
+        "product_list_adjusts_inventory": true,
+        "product_list_adjusts_pricing": true,
+        "product_list_shipping_calc": "weight"
+      },
+      "option_values": [
+        {
+          "id": 102,
+          "option_id": 116,
+          "label": "Husqvarna DS150 Drill Stand Suits Dm230 Drill - DS150",
+          "sort_order": 0,
+          "value_data": {
+            "product_id": 169
+          },
+          "is_default": false,
+          "adjusters": {
+            "price": null,
+            "weight": null,
+            "image_url": "",
+            "purchasing_disabled": {
+              "status": false,
+              "message": ""
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 117,
+      "product_id": 6962,
+      "name": "Dropdown1654474738-6962",
+      "display_name": "Dropdown",
+      "type": "dropdown",
+      "required": false,
+      "sort_order": 9,
+      "config": [],
+      "option_values": [
+        {
+          "id": 103,
+          "option_id": 117,
+          "label": "a",
+          "sort_order": 0,
+          "value_data": null,
+          "is_default": false,
+          "adjusters": {
+            "price": null,
+            "weight": null,
+            "image_url": "",
+            "purchasing_disabled": {
+              "status": false,
+              "message": ""
+            }
+          }
+        },
+        {
+          "id": 104,
+          "option_id": 117,
+          "label": "b",
+          "sort_order": 1,
+          "value_data": null,
+          "is_default": true,
+          "adjusters": {
+            "price": null,
+            "weight": null,
+            "image_url": "",
+            "purchasing_disabled": {
+              "status": false,
+              "message": ""
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 118,
+      "product_id": 6962,
+      "name": "date1654474738-6962",
+      "display_name": "date",
+      "type": "date",
+      "required": false,
+      "sort_order": 9,
+      "config": {
+        "date_limited": false,
+        "date_limit_mode": "earliest",
+        "date_earliest_value": null,
+        "date_latest_value": null,
+        "default_value": "2022-06-01T00:00:00+00:00"
+      },
+      "option_values": []
+    }
+  ],
+  "meta": {
+    "pagination": {
+      "total": 6,
+      "count": 6,
+      "per_page": 50,
+      "current_page": 1,
+      "total_pages": 1,
+      "links": {
+        "current": "?page=1&limit=50"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Implement `ProductModifierConfig` ([API Reference](https://developer.bigcommerce.com/api-reference/c799ca0742d1b-get-all-product-modifiers)) completely and improve testing.

Fixes #135 