### PR TITLE
Feature/144 implement site routes

### DIFF
--- a/src/BigCommerce/Api/Channels/ChannelSitesApi.php
+++ b/src/BigCommerce/Api/Channels/ChannelSitesApi.php
@@ -7,6 +7,7 @@ use BigCommerce\ApiV3\Api\Generic\DeleteResource;
 use BigCommerce\ApiV3\Api\Generic\GetResource;
 use BigCommerce\ApiV3\Api\Generic\UpdateResource;
 use BigCommerce\ApiV3\Api\Generic\V3ApiBase;
+use BigCommerce\ApiV3\Api\Sites\SiteRoutesApi;
 use BigCommerce\ApiV3\ResourceModels\Channel\ChannelSite;
 use BigCommerce\ApiV3\ResponseModels\Channel\ChannelSiteResponse;
 
@@ -42,5 +43,15 @@ class ChannelSitesApi extends V3ApiBase
     public function singleResourceUrl(): string
     {
         return sprintf(self::CHANNEL_SITE_ENDPOINT, $this->getParentResourceId());
+    }
+
+    public function routes(): SiteRoutesApi
+    {
+        return new SiteRoutesApi($this->getClient(), null, $this->getResourceId());
+    }
+
+    public function route(int $id): SiteRoutesApi
+    {
+        return new SiteRoutesApi($this->getClient(), $id, $this->getResourceId());
     }
 }

--- a/src/BigCommerce/Api/Sites/SiteRoutesApi.php
+++ b/src/BigCommerce/Api/Sites/SiteRoutesApi.php
@@ -3,10 +3,10 @@
 namespace BigCommerce\ApiV3\Api\Sites;
 
 use BigCommerce\ApiV3\Api\Generic\ResourceApi;
-use BigCommerce\ApiV3\ResponseModels\PaginatedResponse;
-use BigCommerce\ApiV3\ResponseModels\SingleResourceResponse;
+use BigCommerce\ApiV3\ResourceModels\Site\SiteRoute;
 use BigCommerce\ApiV3\ResponseModels\Site\SiteRouteResponse;
 use BigCommerce\ApiV3\ResponseModels\Site\SiteRoutesResponse;
+use Psr\Http\Message\ResponseInterface;
 
 class SiteRoutesApi extends ResourceApi
 {
@@ -37,5 +37,15 @@ class SiteRoutesApi extends ResourceApi
     public function getAll(array $filters = [], int $page = 1, int $limit = 250): SiteRoutesResponse
     {
         return new SiteRoutesResponse($this->getAllResources($filters, $page, $limit));
+    }
+
+    public function create(SiteRoute $siteRoute): ResponseInterface
+    {
+        return $this->createResource($siteRoute);
+    }
+
+    public function update(SiteRoute $siteRoute): ResponseInterface
+    {
+        return $this->updateResource($siteRoute);
     }
 }

--- a/src/BigCommerce/Api/Sites/SiteRoutesApi.php
+++ b/src/BigCommerce/Api/Sites/SiteRoutesApi.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace BigCommerce\ApiV3\Api\Sites;
+
+use BigCommerce\ApiV3\Api\Generic\ResourceApi;
+use BigCommerce\ApiV3\ResponseModels\PaginatedResponse;
+use BigCommerce\ApiV3\ResponseModels\SingleResourceResponse;
+use BigCommerce\ApiV3\ResponseModels\Site\SiteRouteResponse;
+use BigCommerce\ApiV3\ResponseModels\Site\SiteRoutesResponse;
+
+class SiteRoutesApi extends ResourceApi
+{
+    private const RESOURCE_NAME  = 'routes';
+    private const ROUTES_ENDPOINT = 'sites/%d/routes';
+    private const ROUTE_ENDPOINT  = 'sites/%d/routes/$d';
+
+    protected function singleResourceEndpoint(): string
+    {
+        return self::ROUTE_ENDPOINT;
+    }
+
+    protected function multipleResourcesEndpoint(): string
+    {
+        return self::ROUTES_ENDPOINT;
+    }
+
+    protected function resourceName(): string
+    {
+        return self::RESOURCE_NAME;
+    }
+
+    public function get(): SiteRouteResponse
+    {
+        return new SiteRouteResponse($this->getResource());
+    }
+
+    public function getAll(array $filters = [], int $page = 1, int $limit = 250): SiteRoutesResponse
+    {
+        return new SiteRoutesResponse($this->getAllResources($filters, $page, $limit));
+    }
+}

--- a/src/BigCommerce/Api/Sites/SitesApi.php
+++ b/src/BigCommerce/Api/Sites/SitesApi.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace BigCommerce\ApiV3\Api\Sites;
+
+use BigCommerce\ApiV3\Api\Generic\ResourceApi;
+use BigCommerce\ApiV3\ResponseModels\PaginatedResponse;
+use BigCommerce\ApiV3\ResponseModels\SingleResourceResponse;
+use BigCommerce\ApiV3\ResponseModels\Site\SiteResponse;
+use BigCommerce\ApiV3\ResponseModels\Site\SitesResponse;
+
+class SitesApi extends ResourceApi
+{
+    private const RESOURCE_NAME  = 'sites';
+    private const SITES_ENDPOINT = 'sites';
+    private const SITE_ENDPOINT  = 'sites/%d';
+
+    protected function singleResourceEndpoint(): string
+    {
+        return self::SITE_ENDPOINT;
+    }
+
+    protected function multipleResourcesEndpoint(): string
+    {
+        return self::SITES_ENDPOINT;
+    }
+
+    protected function resourceName(): string
+    {
+        return self::RESOURCE_NAME;
+    }
+
+    public function get(): SiteResponse
+    {
+        return new SiteResponse($this->getResource());
+    }
+
+    public function getAll(array $filters = [], int $page = 1, int $limit = 250): SitesResponse
+    {
+        return new SitesResponse($this->getAllResources($filters, $page, $limit));
+    }
+
+    public function routes()
+    {
+    }
+
+    public function route(int $id)
+    {
+    }
+
+    // certificate?
+}

--- a/src/BigCommerce/Api/Sites/SitesApi.php
+++ b/src/BigCommerce/Api/Sites/SitesApi.php
@@ -3,8 +3,10 @@
 namespace BigCommerce\ApiV3\Api\Sites;
 
 use BigCommerce\ApiV3\Api\Generic\ResourceApi;
+use BigCommerce\ApiV3\ResourceModels\Site\Site;
 use BigCommerce\ApiV3\ResponseModels\Site\SiteResponse;
 use BigCommerce\ApiV3\ResponseModels\Site\SitesResponse;
+use Psr\Http\Message\ResponseInterface;
 
 class SitesApi extends ResourceApi
 {
@@ -35,6 +37,16 @@ class SitesApi extends ResourceApi
     public function getAll(array $filters = [], int $page = 1, int $limit = 250): SitesResponse
     {
         return new SitesResponse($this->getAllResources($filters, $page, $limit));
+    }
+
+    public function create(Site $site): ResponseInterface
+    {
+        return $this->createResource($site);
+    }
+
+    public function update(Site $site): ResponseInterface
+    {
+        return $this->updateResource($site);
     }
 
     public function routes(): SiteRoutesApi

--- a/src/BigCommerce/Api/Sites/SitesApi.php
+++ b/src/BigCommerce/Api/Sites/SitesApi.php
@@ -3,8 +3,6 @@
 namespace BigCommerce\ApiV3\Api\Sites;
 
 use BigCommerce\ApiV3\Api\Generic\ResourceApi;
-use BigCommerce\ApiV3\ResponseModels\PaginatedResponse;
-use BigCommerce\ApiV3\ResponseModels\SingleResourceResponse;
 use BigCommerce\ApiV3\ResponseModels\Site\SiteResponse;
 use BigCommerce\ApiV3\ResponseModels\Site\SitesResponse;
 
@@ -39,13 +37,13 @@ class SitesApi extends ResourceApi
         return new SitesResponse($this->getAllResources($filters, $page, $limit));
     }
 
-    public function routes()
+    public function routes(): SiteRoutesApi
     {
+        return new SiteRoutesApi($this->getClient(), null, $this->getResourceId());
     }
 
-    public function route(int $id)
+    public function route(int $id): SiteRoutesApi
     {
+        return new SiteRoutesApi($this->getClient(), $id, $this->getResourceId());
     }
-
-    // certificate?
 }

--- a/src/BigCommerce/Client.php
+++ b/src/BigCommerce/Client.php
@@ -11,6 +11,7 @@ use BigCommerce\ApiV3\Api\Payments\PaymentsProcessingApi;
 use BigCommerce\ApiV3\Api\PriceLists\PriceListsApi;
 use BigCommerce\ApiV3\Api\Redirects\RedirectsApi;
 use BigCommerce\ApiV3\Api\Scripts\ScriptsApi;
+use BigCommerce\ApiV3\Api\Sites\SitesApi;
 use BigCommerce\ApiV3\Api\Themes\ThemesApi;
 use BigCommerce\ApiV3\Api\Widgets\WidgetsApi;
 use BigCommerce\ApiV3\Api\CustomTemplateAssociations\CustomTemplateAssociationsApi;
@@ -177,6 +178,16 @@ class Client extends BaseApiClient
     public function redirects(): RedirectsApi
     {
         return new RedirectsApi($this);
+    }
+
+    public function sites(): SitesApi
+    {
+        return new SitesApi($this);
+    }
+
+    public function site(int $id): SitesApi
+    {
+        return new SitesApi($this, $id);
     }
 
     protected function defaultBaseUrl(): string

--- a/src/BigCommerce/ResourceModels/Site/Site.php
+++ b/src/BigCommerce/ResourceModels/Site/Site.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResourceModels\Site;
+
+use BigCommerce\ApiV3\ResourceModels\ResourceModel;
+
+class Site extends ResourceModel
+{
+    public const SSL_STATUS_DEDICATED = 'dedicated';
+    public const SSL_STATUS_SHARED    = 'shared';
+
+    public int $id;
+    public string $url;
+    public int $channel_id;
+    public string $created_at;
+    public string $updated_at;
+    public string $ssl_status;
+    /**
+     * @var SiteUrl[]
+     */
+    public array $urls;
+    public bool $is_checkout_url_customized;
+
+    protected function beforeBuildObject(): void
+    {
+        $this->buildObjectArray('urls', SiteUrl::class);
+    }
+}

--- a/src/BigCommerce/ResourceModels/Site/SiteRoute.php
+++ b/src/BigCommerce/ResourceModels/Site/SiteRoute.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResourceModels\Site;
+
+use BigCommerce\ApiV3\ResourceModels\ResourceModel;
+
+class SiteRoute extends ResourceModel
+{
+    public const TYPE_PRODUCT = 'product';
+    public const TYPE_BRAND = 'brand';
+    public const TYPE_CATEGORY = 'category';
+    public const TYPE_PAGE = 'page';
+    public const TYPE_BLOG = 'blog';
+    public const TYPE_HOME = 'home';
+    public const TYPE_CART = 'cart';
+    public const TYPE_CHECKOUT = 'checkout';
+    public const TYPE_SEARCH = 'search';
+    public const TYPE_ACCOUNT = 'account';
+    public const TYPE_LOGIN = 'login';
+    public const TYPE_RETURNS = 'returns';
+    public const TYPE_STATIC = 'static';
+
+    public int $id;
+    public string $type;
+    public string $matching;
+    public string $route;
+}

--- a/src/BigCommerce/ResourceModels/Site/SiteUrl.php
+++ b/src/BigCommerce/ResourceModels/Site/SiteUrl.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResourceModels\Site;
+
+use BigCommerce\ApiV3\ResourceModels\ResourceModel;
+
+class SiteUrl extends ResourceModel
+{
+    public const TYPE_PRIMARY   = 'primary';
+    public const TYPE_CANONICAL = 'canonical';
+    public const TYPE_CHECKOUT  = 'checkout';
+
+    public string $url;
+    public string $type;
+    public string $created_at;
+    public string $updated_at;
+}

--- a/src/BigCommerce/ResponseModels/Site/SiteResponse.php
+++ b/src/BigCommerce/ResponseModels/Site/SiteResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResponseModels\Site;
+
+use BigCommerce\ApiV3\ResourceModels\Site\Site;
+use BigCommerce\ApiV3\ResponseModels\SingleResourceResponse;
+use stdClass;
+
+class SiteResponse extends SingleResourceResponse
+{
+    private Site $site;
+
+    public function getSite(): Site
+    {
+        return $this->site;
+    }
+
+    protected function addData(stdClass $rawData): void
+    {
+        $this->site = new Site($rawData);
+    }
+}

--- a/src/BigCommerce/ResponseModels/Site/SiteRouteResponse.php
+++ b/src/BigCommerce/ResponseModels/Site/SiteRouteResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResponseModels\Site;
+
+use BigCommerce\ApiV3\ResourceModels\Site\SiteRoute;
+use BigCommerce\ApiV3\ResponseModels\SingleResourceResponse;
+use stdClass;
+
+class SiteRouteResponse extends SingleResourceResponse
+{
+    private SiteRoute $siteRoute;
+
+    public function getSiteRoute(): SiteRoute
+    {
+        return $this->siteRoute;
+    }
+
+    protected function addData(stdClass $rawData): void
+    {
+        $this->siteRoute = new SiteRoute($rawData);
+    }
+}

--- a/src/BigCommerce/ResponseModels/Site/SiteRoutesResponse.php
+++ b/src/BigCommerce/ResponseModels/Site/SiteRoutesResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResponseModels\Site;
+
+use BigCommerce\ApiV3\ResourceModels\Site\SiteRoute;
+use BigCommerce\ApiV3\ResponseModels\PaginatedResponse;
+
+class SiteRoutesResponse extends PaginatedResponse
+{
+    /**
+     * @return SiteRoute[]
+     */
+    public function getRoutes(): array
+    {
+        return $this->getData();
+    }
+
+    protected function resourceClass(): string
+    {
+        return SiteRoute::class;
+    }
+}

--- a/src/BigCommerce/ResponseModels/Site/SitesResponse.php
+++ b/src/BigCommerce/ResponseModels/Site/SitesResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResponseModels\Site;
+
+use BigCommerce\ApiV3\ResourceModels\Site\Site;
+use BigCommerce\ApiV3\ResponseModels\PaginatedResponse;
+
+class SitesResponse extends PaginatedResponse
+{
+    /**
+     * @return Site[]
+     */
+    public function getSites(): array
+    {
+        return $this->getData();
+    }
+
+    protected function resourceClass(): string
+    {
+        return Site::class;
+    }
+}

--- a/tests/BigCommerce/Api/Sites/SiteRoutesApiTest.php
+++ b/tests/BigCommerce/Api/Sites/SiteRoutesApiTest.php
@@ -24,6 +24,13 @@ class SiteRoutesApiTest extends BigCommerceApiTest
 
     public function testCanCreateRoute()
     {
-        $this->markTestIncomplete();
+        $this->setReturnData('blank.json');
+        $route = new SiteRoute();
+        $route->route = '/checkout';
+        $route->type = SiteRoute::TYPE_CHECKOUT;
+        $route->matching = '*';
+
+        $response = $this->getApi()->site(1)->routes()->create($route);
+        $this->assertEquals(200, $response->getStatusCode());
     }
 }

--- a/tests/BigCommerce/Api/Sites/SiteRoutesApiTest.php
+++ b/tests/BigCommerce/Api/Sites/SiteRoutesApiTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace BigCommerce\Tests\Api\Sites;
+
+use BigCommerce\ApiV3\ResourceModels\Site\SiteRoute;
+use BigCommerce\Tests\BigCommerceApiTest;
+
+class SiteRoutesApiTest extends BigCommerceApiTest
+{
+    public function testCanGetRoutes()
+    {
+        $this->setReturnData('site__routes__get_all.json');
+        $routes = $this->getApi()->site(1)->routes()->getAll()->getRoutes();
+        $this->assertCount(2, $routes);
+        $this->assertEquals(SiteRoute::TYPE_PRODUCT, $routes[0]->type);
+    }
+
+    public function testCanGetRoute()
+    {
+        $this->setReturnData('site__route__60474753_get.json');
+        $route = $this->getApi()->site(1)->route(60474753)->get()->getSiteRoute();
+        $this->assertEquals('/my-amazing-product', $route->route);
+    }
+
+    public function testCanCreateRoute()
+    {
+        $this->markTestIncomplete();
+    }
+}

--- a/tests/BigCommerce/Api/Sites/SitesApiTest.php
+++ b/tests/BigCommerce/Api/Sites/SitesApiTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace BigCommerce\Tests\Api\Sites;
+
+use BigCommerce\ApiV3\ResourceModels\Site\Site;
+use BigCommerce\Tests\BigCommerceApiTest;
+
+class SitesApiTest extends BigCommerceApiTest
+{
+    public function testCanGetSite()
+    {
+        $this->setReturnData('sites__23__get.json');
+        $site = $this->getApi()->site(23)->get()->getSite();
+        $this->assertEquals('https://example.com', $site->url);
+        $this->assertEquals('https://checkout.example.com', $site->urls[2]->url);
+    }
+
+    public function testCanGetSites()
+    {
+        $this->setReturnData('sites__get_all.json');
+        $sites = $this->getApi()->sites()->getAll()->getSites();
+        $this->assertEquals(Site::SSL_STATUS_DEDICATED, $sites[0]->ssl_status);
+    }
+}

--- a/tests/BigCommerce/responses/site__route__60474753_get.json
+++ b/tests/BigCommerce/responses/site__route__60474753_get.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "id": 60474753,
+    "type": "checkout",
+    "matching": "5",
+    "route": "/my-amazing-product"
+  },
+  "meta": {}
+}

--- a/tests/BigCommerce/responses/site__routes__get_all.json
+++ b/tests/BigCommerce/responses/site__routes__get_all.json
@@ -1,0 +1,25 @@
+{
+  "data": [
+    {
+      "id": 1,
+      "type": "product",
+      "matching": "5",
+      "route": "/products?id={id}"
+    },
+    {
+      "id": 2,
+      "type": "category",
+      "matching": "44",
+      "route": "/category/{slug}"
+    }
+  ],
+  "meta": {
+    "pagination": {
+      "total": 1,
+      "count": 1,
+      "per_page": 50,
+      "current_page": 1,
+      "total_pages": 1
+    }
+  }
+}

--- a/tests/BigCommerce/responses/sites__23__get.json
+++ b/tests/BigCommerce/responses/sites__23__get.json
@@ -1,0 +1,38 @@
+{
+  "data": {
+    "id": 23,
+    "url": "https://example.com",
+    "channel_id": 234,
+    "created_at": "2018-01-04T04:15:50.000Z",
+    "updated_at": "2018-01-04T04:15:50.000Z",
+    "ssl_status": "dedicated",
+    "urls": [
+      {
+        "url": "https://example.com",
+        "type": "primary",
+        "created_at": "2020-11-03T19:26:12Z",
+        "updated_at": "2021-08-31T21:46:50Z"
+      },
+      {
+        "url": "https://store-29i23fcz6.mybigcommerce.com",
+        "type": "canonical",
+        "created_at": "2020-11-03T19:26:12Z",
+        "updated_at": "2020-11-03T19:26:12Z"
+      },
+      {
+        "url": "https://checkout.example.com",
+        "type": "checkout",
+        "created_at": "2020-11-03T19:26:12Z",
+        "updated_at": "2021-08-31T21:46:50Z"
+      }
+    ],
+    "is_checkout_url_customized": true
+  },
+  "meta": {
+    "pagination": {
+      "offset": 0,
+      "limit": 50,
+      "total_items": 1
+    }
+  }
+}

--- a/tests/BigCommerce/responses/sites__get_all.json
+++ b/tests/BigCommerce/responses/sites__get_all.json
@@ -1,0 +1,35 @@
+{
+  "data": [
+    {
+      "id": 0,
+      "url": "http://kittens.mybigcommerce.com/",
+      "channel_id": 0,
+      "created_at": "2018-01-04T04:15:50.000Z",
+      "updated_at": "2018-01-04T04:15:50.000Z",
+      "ssl_status": "dedicated",
+      "urls": [
+        {
+          "url": "string",
+          "type": "primary",
+          "created_at": "2018-01-04T04:15:50.000Z",
+          "updated_at": "2018-01-04T04:15:50.000Z"
+        }
+      ],
+      "is_checkout_url_customized": true
+    }
+  ],
+  "meta": {
+    "pagination": {
+      "total": 3,
+      "count": 1,
+      "per_page": 1,
+      "current_page": 2,
+      "total_page": 3,
+      "links": {
+        "previous": "?limit=1&page=1",
+        "next": "?limit=1&page=3",
+        "current": "?limit=1&page=2"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Implement the Sites and Site Routes apis. Sites is also available under Channel Sites, so this adds a link between the two.

It does introduce a little bit of duplicated code, but just incase the two apis aren't exactly the same I think this is acceptable.

Fixes #144 