### PR TITLE
Fix/150 product modifer value missing value data

### DIFF
--- a/src/BigCommerce/ResourceModels/Catalog/Product/ProductModifier.php
+++ b/src/BigCommerce/ResourceModels/Catalog/Product/ProductModifier.php
@@ -39,7 +39,7 @@ class ProductModifier extends ResourceModel
 
         if (!is_null($optionObject) && isset($optionObject->option_values)) {
             $this->option_values = array_map(function ($v) {
-                return ProductModifierValue::buildFromResponse($v);
+                return new ProductModifierValue($v);
             }, $optionObject->option_values);
             unset($optionObject->option_values);
         }

--- a/src/BigCommerce/ResourceModels/Catalog/Product/ProductModifierValue.php
+++ b/src/BigCommerce/ResourceModels/Catalog/Product/ProductModifierValue.php
@@ -2,9 +2,9 @@
 
 namespace BigCommerce\ApiV3\ResourceModels\Catalog\Product;
 
-use JsonSerializable;
+use BigCommerce\ApiV3\ResourceModels\ResourceModel;
 
-class ProductModifierValue implements JsonSerializable
+class ProductModifierValue extends ResourceModel
 {
     public int $id;
     public int $option_id;
@@ -13,45 +13,19 @@ class ProductModifierValue implements JsonSerializable
     public bool $is_default = false;
     public int $sort_order;
     public ?ProductModifierValueAdjuster $adjusters;
+    /**
+     * Extra data describing the value, based on the type of option or modifier with which the value is associated.
+     * The swatch type option can accept an array of colors, with up to three hexidecimal color keys; or an image_url,
+     * which is a full image URL path including protocol. The product list type option requires a product_id.
+     * The checkbox type option requires a boolean flag, called checked_value, to determine which value is considered
+     * to be the checked state. If no data is available, returns null.
+     */
+    public ?ProductModifierValueData $value_data;
 
-    public function __construct(?int $productId, string $label)
+    protected function beforeBuildObject(): void
     {
-        $this->productId = $productId;
-        $this->label = $label;
-    }
-
-    public static function buildFromResponse(\stdClass $optionObject): ProductModifierValue
-    {
-        $modifierValue = new ProductModifierValue(null, '');
-        foreach ($optionObject as $key => $value) {
-            switch ($key) {
-                case 'adjusters':
-                    $modifierValue->$key = new ProductModifierValueAdjuster($optionObject->$key);
-                    break;
-                default:
-                    $modifierValue->$key = $value;
-            }
-        }
-
-        return $modifierValue;
-    }
-
-    public function jsonSerialize(): array
-    {
-        $json = [
-            'is_default' => $this->is_default,
-            'label'      => $this->label,
-            'sort_order' => $this->sort_order,
-        ];
-
-        if (isset($this->adjusters)) {
-            $json['adjusters'] = $this->adjusters;
-        }
-        if (isset($this->productId) && $this->productId > 0) {
-            $json['value_data'] = ['product_id' => $this->productId];
-        }
-
-        return $json;
+        $this->buildPropertyObject('adjusters', ProductModifierValueAdjuster::class);
+        $this->buildPropertyObject('value_data', ProductModifierValueData::class);
     }
 
     public function addPriceAdjuster(PriceAdjuster $priceAdjuster)

--- a/src/BigCommerce/ResourceModels/Catalog/Product/ProductModifierValueAdjuster.php
+++ b/src/BigCommerce/ResourceModels/Catalog/Product/ProductModifierValueAdjuster.php
@@ -12,16 +12,9 @@ class ProductModifierValueAdjuster extends ResourceModel
     public string $image_url;
     public object $purchasing_disabled;
 
-    public function __construct(?stdClass $optionObject = null)
+    protected function beforeBuildObject(): void
     {
-        if (!is_null($optionObject)) {
-            $this->price = new PriceAdjuster($optionObject->price);
-            unset($optionObject->price);
-
-            $this->weight = new WeightAdjuster($optionObject->weight);
-            unset($optionObject->weight);
-        }
-
-        parent::__construct($optionObject);
+        $this->buildPropertyObject('price', PriceAdjuster::class);
+        $this->buildPropertyObject('weight', WeightAdjuster::class);
     }
 }

--- a/src/BigCommerce/ResourceModels/Catalog/Product/ProductModifierValueData.php
+++ b/src/BigCommerce/ResourceModels/Catalog/Product/ProductModifierValueData.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResourceModels\Catalog\Product;
+
+use BigCommerce\ApiV3\ResourceModels\ResourceModel;
+
+class ProductModifierValueData extends ResourceModel
+{
+    public ?array $colors;
+    public ?string $image_url;
+    public ?int $product_id;
+    public ?bool $checked_value;
+}

--- a/src/BigCommerce/ResponseModels/Product/ProductModifierValueResponse.php
+++ b/src/BigCommerce/ResponseModels/Product/ProductModifierValueResponse.php
@@ -17,6 +17,6 @@ class ProductModifierValueResponse extends SingleResourceResponse
 
     protected function addData(stdClass $rawData): void
     {
-        $this->modifierValue = ProductModifierValue::buildFromResponse($rawData);
+        $this->modifierValue = new ProductModifierValue($rawData);
     }
 }

--- a/src/BigCommerce/ResponseModels/Product/ProductModifierValuesResponse.php
+++ b/src/BigCommerce/ResponseModels/Product/ProductModifierValuesResponse.php
@@ -18,7 +18,7 @@ class ProductModifierValuesResponse extends PaginatedResponse
     protected function addData(array $data): void
     {
         $this->setData(array_map(function (\stdClass $v) {
-            return ProductModifierValue::buildFromResponse($v);
+            return new ProductModifierValue($v);
         }, $data));
     }
 

--- a/tests/BigCommerce/Api/Catalog/Products/ProductModifier/ProductModifierValuesApiTest.php
+++ b/tests/BigCommerce/Api/Catalog/Products/ProductModifier/ProductModifierValuesApiTest.php
@@ -1,0 +1,70 @@
+<?php
+namespace BigCommerce\Tests\Api\Catalog\Products\ProductModifier;
+
+use BigCommerce\Tests\BigCommerceApiTest;
+
+class ProductModifierValuesApiTest extends BigCommerceApiTest
+{
+    public function testCanGetModifierValue()
+    {
+        $this->setReturnData('catalog__products__modifiers__222__values__190__get.json');
+
+        $modifierValue = $this->getApi()
+            ->catalog()->product(1)->modifier(222)->value(190)->get()->getModifierValue();
+
+        $this->assertEquals('Yes', $modifierValue->label);
+        $this->assertEquals(5, $modifierValue->adjusters->price->adjuster_value);
+    }
+
+    public function testCanGetModifierValues()
+    {
+        $this->setReturnData('catalog__products__modifiers__222__values__get_all.json');
+
+        $modifierValues = $this->getApi()
+            ->catalog()->product(1)->modifier(222)->values()->getAll()->getModifierValues();
+
+        $this->assertCount(2, $modifierValues);
+        $this->assertTrue($modifierValues[0]->value_data->checked_value);
+        $this->assertTrue($modifierValues[1]->value_data->checked_value);
+    }
+
+    public function testCanUpdateModifierValue()
+    {
+        $this->setReturnData('catalog__products__modifiers__222__values__190__get.json');
+
+        $modifierValue = $this->getApi()
+            ->catalog()->product(1)->modifier(222)->value(190)->get()->getModifierValue();
+
+        $modifierValue->value_data->checked_value = false;
+        $modifierValue->label = "Yesish";
+
+        $expectedJson = <<<EOT
+{
+    "id": 190,
+    "option_id": 222,
+    "label": "Yesish",
+    "sort_order": 0,
+    "value_data": {
+        "checked_value": true
+    },
+    "value_data": {},
+    "is_default": false,
+    "adjusters": {
+      "price": {
+        "adjuster": "relative",
+        "adjuster_value": 5
+      },
+      "weight": {},
+      "image_url": "",
+      "purchasing_disabled": {
+        "status": false,
+        "message": ""
+      }
+    }
+  }
+EOT;
+
+
+        $this->assertJsonStringEqualsJsonString($expectedJson, json_encode($modifierValue));
+    }
+}

--- a/tests/BigCommerce/Api/Catalog/Products/ProductModifier/ProductModifierValuesApiTest.php
+++ b/tests/BigCommerce/Api/Catalog/Products/ProductModifier/ProductModifierValuesApiTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace BigCommerce\Tests\Api\Catalog\Products\ProductModifier;
 
+use BigCommerce\ApiV3\ResourceModels\Catalog\Product\ProductModifierValueData;
 use BigCommerce\Tests\BigCommerceApiTest;
 
 class ProductModifierValuesApiTest extends BigCommerceApiTest
@@ -25,7 +26,7 @@ class ProductModifierValuesApiTest extends BigCommerceApiTest
 
         $this->assertCount(2, $modifierValues);
         $this->assertTrue($modifierValues[0]->value_data->checked_value);
-        $this->assertTrue($modifierValues[1]->value_data->checked_value);
+        $this->assertFalse($modifierValues[1]->value_data->checked_value);
     }
 
     public function testCanUpdateModifierValue()
@@ -35,6 +36,7 @@ class ProductModifierValuesApiTest extends BigCommerceApiTest
         $modifierValue = $this->getApi()
             ->catalog()->product(1)->modifier(222)->value(190)->get()->getModifierValue();
 
+        $modifierValue->value_data = new ProductModifierValueData();
         $modifierValue->value_data->checked_value = false;
         $modifierValue->label = "Yesish";
 
@@ -45,16 +47,14 @@ class ProductModifierValuesApiTest extends BigCommerceApiTest
     "label": "Yesish",
     "sort_order": 0,
     "value_data": {
-        "checked_value": true
+        "checked_value": false
     },
-    "value_data": {},
     "is_default": false,
     "adjusters": {
       "price": {
         "adjuster": "relative",
         "adjuster_value": 5
       },
-      "weight": {},
       "image_url": "",
       "purchasing_disabled": {
         "status": false,

--- a/tests/BigCommerce/Api/Catalog/Products/ProductModifier/ProductModifierValuesApiTest.php
+++ b/tests/BigCommerce/Api/Catalog/Products/ProductModifier/ProductModifierValuesApiTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace BigCommerce\Tests\Api\Catalog\Products\ProductModifier;
 
 use BigCommerce\ApiV3\ResourceModels\Catalog\Product\ProductModifierValueData;

--- a/tests/BigCommerce/responses/catalog__products__modifiers__222__values__190__get.json
+++ b/tests/BigCommerce/responses/catalog__products__modifiers__222__values__190__get.json
@@ -4,14 +4,14 @@
     "option_id": 222,
     "label": "Yes",
     "sort_order": 0,
-    "value_data": {},
+    "value_data": null,
     "is_default": false,
     "adjusters": {
       "price": {
         "adjuster": "relative",
         "adjuster_value": 5
       },
-      "weight": {},
+      "weight": null,
       "image_url": "",
       "purchasing_disabled": {
         "status": false,


### PR DESCRIPTION
Fix update the `ProductModifierValues` class to be a simpler and correct. Added tests for the api.

Fixes #150 