### PR TITLE
Update to StoreInformation API Class

### DIFF
--- a/src/BigCommerceLegacyApi/Api/StoreInformation/StoreInformationApi.php
+++ b/src/BigCommerceLegacyApi/Api/StoreInformation/StoreInformationApi.php
@@ -15,8 +15,20 @@ class StoreInformationApi extends V2ApiBase
      *
      * @return StoreInformation
      * @throws \GuzzleHttp\Exception\GuzzleException
+     * @deprecated Replaced by `get()` function.
      */
     public function storeInformation(): StoreInformation
+    {
+        return $this->get();
+    }
+
+    /**
+     * Returns metadata about a store.
+     *
+     * @return StoreInformation
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function get(): StoreInformation
     {
         $response = $this->getClient()->getRestClient()->get(
             self::STORE_INFORMATION_ENDPOINT

--- a/tests/BigCommerceLegacyApi/Api/StoreInformation/StoreInformationApiTest.php
+++ b/tests/BigCommerceLegacyApi/Api/StoreInformation/StoreInformationApiTest.php
@@ -17,7 +17,7 @@ class StoreInformationApiTest extends V2ApiClientTest
     {
         $this->setReturnData('storeinformation_store.json');
 
-        $information = $this->getApi()->storeInformation()->storeInformation();
+        $information = $this->getApi()->storeInformation()->get();
 
         $this->assertEquals('BigCommerce', $information->name);
         $this->assertEquals('my-awesome.store', $information->domain);
@@ -33,7 +33,7 @@ class StoreInformationApiTest extends V2ApiClientTest
         //Weird API design means the logo is set to empty array if no logo present
         $this->setReturnData('storeinformation_store__no-logo.json');
 
-        $information = $this->getApi()->storeInformation()->storeInformation();
+        $information = $this->getApi()->storeInformation()->get();
 
         $this->assertEquals('MLITest', $information->name);
         $this->assertNull($information->logo);


### PR DESCRIPTION
`BigCommerce\ApiV2\Api\StoreInformation\StoreInformation`
* Added `get()` function to match other API classes.
* Updated `storeInformation()` function to use `get()` function if called.
* Marked `storeInformation()` function as deprecated.

Calling the StoreInformation API
Before `$api->storeInformation()->storeInformation();`
After `$api->storeInformation()->get();`