### PR TITLE
Update BaseApiClient.php

### DIFF
--- a/src/BigCommerce/BaseApiClient.php
+++ b/src/BigCommerce/BaseApiClient.php
@@ -9,6 +9,7 @@ abstract class BaseApiClient
 {
     public const DEFAULT_HANDLER      = 'handler';
     public const DEFAULT_BASE_URI     = 'base_uri';
+    public const TIMEOUT              = 'timeout';
     public const DEFAULT_HEADERS      = 'headers';
 
     private const HEADERS__AUTH_CLIENT  = 'X-Auth-Client';
@@ -52,6 +53,7 @@ abstract class BaseApiClient
         return new \GuzzleHttp\Client([
             self::DEFAULT_HANDLER  => $stack,
             self::DEFAULT_BASE_URI => $this->getBaseUri(),
+            self::TIMEOUT          => 45,
             self::DEFAULT_HEADERS  => [
                 self::HEADERS__AUTH_CLIENT  => $this->clientId,
                 self::HEADERS__AUTH_TOKEN   => $this->accessToken,


### PR DESCRIPTION
Guzzle default behavior is to wait forever, without any timeout. From https://docs.guzzlephp.org/en/stable/request-options.html#timeout :

> Use 0 to wait indefinitely (the default behavior).

Without a defined `timeout`, the application hangs if BigCommerce doesn't provide a response. I've seen an application remain open for days with an ESTABLISHED TCP connection to BigCommerce.

This edit fixes it, giving BigCommece 45 seconds to provide a response before a timeout is thrown.