### PR TITLE
Add page_title property to Brand, fixes #171

### DIFF
--- a/src/BigCommerce/ResourceModels/Catalog/Brand/Brand.php
+++ b/src/BigCommerce/ResourceModels/Catalog/Brand/Brand.php
@@ -16,6 +16,7 @@ class Brand extends ResourceModel
     public ?string $meta_description;
     public string $image_url;
     public string $search_keywords;
+    public string $page_title;
 
     public function __construct(?stdClass $optionObject = null)
     {


### PR DESCRIPTION
Fixed missing property `page_title` that was causing a deprecation warning notice. Documentation for Brand: https://developer.bigcommerce.com/api-reference/392e318b52baf-get-a-brand

Fixes #171 