### PR TITLE
Handle the case of no orders returned in the V2 api. Fixes #161

### DIFF
--- a/src/BigCommerceLegacyApi/Api/Orders/OrdersApi.php
+++ b/src/BigCommerceLegacyApi/Api/Orders/OrdersApi.php
@@ -86,7 +86,9 @@ class OrdersApi extends V2ApiBase
     {
         $response = $this->getAllResources($filters, $page, $limit);
 
-        if ($response->getStatusCode() === 204) return [];
+        if ($response->getStatusCode() === 204) {
+            return [];
+        }
 
         return array_map(fn($r) => new OrderResponse($r), json_decode($response->getBody()));
     }

--- a/src/BigCommerceLegacyApi/Api/Orders/OrdersApi.php
+++ b/src/BigCommerceLegacyApi/Api/Orders/OrdersApi.php
@@ -86,6 +86,8 @@ class OrdersApi extends V2ApiBase
     {
         $response = $this->getAllResources($filters, $page, $limit);
 
+        if ($response->getStatusCode() === 204) return [];
+
         return array_map(fn($r) => new OrderResponse($r), json_decode($response->getBody()));
     }
 


### PR DESCRIPTION
Fixes issue where the V2 API returns a 204 with no body when there are no orders. The client will now catch this and return an empty array to match the V3 functionality.

Fixes #161 