### PR TITLE
Feature/185 implement store logs

### DIFF
--- a/src/BigCommerce/Api/StoreLogs/StoreLogsApi.php
+++ b/src/BigCommerce/Api/StoreLogs/StoreLogsApi.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BigCommerce\ApiV3\Api\StoreLogs;
+
+use BigCommerce\ApiV3\Api\Generic\V3ApiBase;
+use BigCommerce\ApiV3\ResponseModels\StoreLogs\SystemLogsResponse;
+use GuzzleHttp\RequestOptions;
+
+class StoreLogsApi extends V3ApiBase
+{
+    public const SYSTEM_LOGS_ENDPOINT = 'store/systemlogs';
+
+    public function get(array $queryParams = []): SystemLogsResponse
+    {
+        return new SystemLogsResponse($this->getClient()->getRestClient()->get(
+            self::SYSTEM_LOGS_ENDPOINT,
+            [
+                RequestOptions::QUERY => $queryParams,
+            ]
+        ));
+    }
+}

--- a/src/BigCommerce/Client.php
+++ b/src/BigCommerce/Client.php
@@ -12,6 +12,7 @@ use BigCommerce\ApiV3\Api\PriceLists\PriceListsApi;
 use BigCommerce\ApiV3\Api\Redirects\RedirectsApi;
 use BigCommerce\ApiV3\Api\Scripts\ScriptsApi;
 use BigCommerce\ApiV3\Api\Sites\SitesApi;
+use BigCommerce\ApiV3\Api\StoreLogs\StoreLogsApi;
 use BigCommerce\ApiV3\Api\Themes\ThemesApi;
 use BigCommerce\ApiV3\Api\Widgets\WidgetsApi;
 use BigCommerce\ApiV3\Api\CustomTemplateAssociations\CustomTemplateAssociationsApi;
@@ -188,6 +189,11 @@ class Client extends BaseApiClient
     public function site(int $id): SitesApi
     {
         return new SitesApi($this, $id);
+    }
+
+    public function storeLogs(): StoreLogsApi
+    {
+        return new StoreLogsApi($this);
     }
 
     protected function defaultBaseUrl(): string

--- a/src/BigCommerce/ResourceModels/SystemLog/SystemLog.php
+++ b/src/BigCommerce/ResourceModels/SystemLog/SystemLog.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResourceModels\SystemLog;
+
+use BigCommerce\ApiV3\ResourceModels\ResourceModel;
+
+class SystemLog extends ResourceModel
+{
+    public int $id;
+    public string $type;
+    public string $module;
+    public string $severity;
+    public string $summary;
+    public string $message;
+    public string $date_created;
+}

--- a/src/BigCommerce/ResponseModels/StoreLogs/SystemLogsResponse.php
+++ b/src/BigCommerce/ResponseModels/StoreLogs/SystemLogsResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResponseModels\StoreLogs;
+
+use BigCommerce\ApiV3\ResourceModels\SystemLog\SystemLog;
+use BigCommerce\ApiV3\ResponseModels\PaginatedResponse;
+
+class SystemLogsResponse extends PaginatedResponse
+{
+    /**
+     * @return SystemLog[]
+     */
+    public function getSystemLogs(): array
+    {
+        return $this->getData();
+    }
+
+    protected function resourceClass(): string
+    {
+        return SystemLog::class;
+    }
+}

--- a/tests/BigCommerce/Api/StoreLogs/StoreLogsApiTest.php
+++ b/tests/BigCommerce/Api/StoreLogs/StoreLogsApiTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace BigCommerce\Tests\Api\StoreLogs;
+
+use BigCommerce\Tests\BigCommerceApiTest;
+
+class StoreLogsApiTest extends BigCommerceApiTest
+{
+    public function testCanGetSystemLogs()
+    {
+        $this->setReturnData('storelogs__systemlogs__get.json');
+
+        $logs = $this->getApi()->storeLogs()->get()->getSystemLogs();
+
+        $this->assertEquals('2019-08-24T14:15:22Z', $logs[0]->date_created);
+    }
+}

--- a/tests/BigCommerce/responses/storelogs__systemlogs__get.json
+++ b/tests/BigCommerce/responses/storelogs__systemlogs__get.json
@@ -1,0 +1,27 @@
+{
+  "data": [
+    {
+      "id": 0,
+      "type": "string",
+      "module": "string",
+      "severity": "string",
+      "summary": "string",
+      "message": "string",
+      "date_created": "2019-08-24T14:15:22Z"
+    }
+  ],
+  "meta": {
+    "pagination": {
+      "total": 1,
+      "count": 1,
+      "per_page": 50,
+      "current_page": 1,
+      "total_pages": 1,
+      "links": {
+        "previous": "?page=1&limit=50",
+        "current": "?page=1&limit=50",
+        "next": "?page=1&limit=50"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add support for store logs. https://developer.bigcommerce.com/api-reference/6908d02370409-get-system-logs

The API is currently called Store Logs, with one endpoint called Get System Logs, so I've called the API Store Logs, but the object and response is SystemLog.

Fixes #185 