### PR TITLE
Feature/181 support additional customer endpoints

### DIFF
--- a/src/BigCommerce/Api/Customers/CustomerSettingsApi.php
+++ b/src/BigCommerce/Api/Customers/CustomerSettingsApi.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace BigCommerce\ApiV3\Api\Customers;
+
+use BigCommerce\ApiV3\Api\Generic\GetResource;
+use BigCommerce\ApiV3\Api\Generic\UpdateResource;
+use BigCommerce\ApiV3\Api\Generic\V3ApiBase;
+use BigCommerce\ApiV3\ResourceModels\Customer\CustomerSettings;
+use BigCommerce\ApiV3\ResponseModels\Customer\CustomerSettingsResponse;
+
+class CustomerSettingsApi extends V3ApiBase
+{
+    use GetResource;
+    use UpdateResource;
+
+    public const CUSTOMER_SETTINGS_ENDPOINT = 'customers/settings';
+
+    public function get(): CustomerSettingsResponse
+    {
+        return new CustomerSettingsResponse($this->getResource());
+    }
+
+    public function singleResourceUrl(): string
+    {
+        return self::CUSTOMER_SETTINGS_ENDPOINT;
+    }
+
+    public function update(CustomerSettings $settings): CustomerSettingsResponse
+    {
+        return new CustomerSettingsResponse($this->updateResource($settings));
+    }
+}

--- a/src/BigCommerce/Api/Customers/CustomerSettingsApi.php
+++ b/src/BigCommerce/Api/Customers/CustomerSettingsApi.php
@@ -29,4 +29,9 @@ class CustomerSettingsApi extends V3ApiBase
     {
         return new CustomerSettingsResponse($this->updateResource($settings));
     }
+
+    public function channel(int $channelId): CustomerSettingsPerChannelApi
+    {
+        return new CustomerSettingsPerChannelApi($this->getClient(), $channelId);
+    }
 }

--- a/src/BigCommerce/Api/Customers/CustomerSettingsPerChannelApi.php
+++ b/src/BigCommerce/Api/Customers/CustomerSettingsPerChannelApi.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace BigCommerce\ApiV3\Api\Customers;
+
+use BigCommerce\ApiV3\Api\Generic\GetResource;
+use BigCommerce\ApiV3\Api\Generic\ResourceApi;
+use BigCommerce\ApiV3\Api\Generic\UpdateResource;
+use BigCommerce\ApiV3\ResourceModels\Customer\CustomerChannelSettings;
+use BigCommerce\ApiV3\ResponseModels\Customer\CustomerChannelSettingsResponse;
+use BigCommerce\ApiV3\ResponseModels\PaginatedResponse;
+
+class CustomerSettingsPerChannelApi extends ResourceApi
+{
+    use GetResource;
+    use UpdateResource;
+
+    private const SETTINGS_PER_CHANNEL_ENDPOINT = 'customers/settings/channels/%d';
+
+
+    protected function singleResourceEndpoint(): string
+    {
+        return self::SETTINGS_PER_CHANNEL_ENDPOINT;
+    }
+
+    protected function multipleResourcesEndpoint(): string
+    {
+        return self::SETTINGS_PER_CHANNEL_ENDPOINT;
+    }
+
+    protected function resourceName(): string
+    {
+        return 'settings';
+    }
+
+    public function get(): CustomerChannelSettingsResponse
+    {
+        return new CustomerChannelSettingsResponse($this->getResource());
+    }
+
+    public function update(CustomerChannelSettings $channelSettings): CustomerChannelSettingsResponse
+    {
+        return new CustomerChannelSettingsResponse($this->updateResource($channelSettings));
+    }
+
+    public function getAll(array $filters = [], int $page = 1, int $limit = 250): PaginatedResponse
+    {
+        throw new \UnexpectedValueException("Unable to get all Customer Settings Per Channel");
+    }
+}

--- a/src/BigCommerce/Api/Customers/CustomersApi.php
+++ b/src/BigCommerce/Api/Customers/CustomersApi.php
@@ -71,8 +71,11 @@ class CustomersApi extends CustomerApiBase
         return new CustomersResponse($this->updateResources($customers));
     }
 
-    public function validateCredentials(string $email, string $password, ?int $channel_id = null): ValidateCredentialsResponse
-    {
+    public function validateCredentials(
+        string $email,
+        string $password,
+        ?int $channel_id = null
+    ): ValidateCredentialsResponse {
         $credentials = ['email' => $email, 'password' => $password];
         if (!is_null($channel_id)) {
             $credentials['channel_id'] = $channel_id;

--- a/src/BigCommerce/Api/Customers/CustomersApi.php
+++ b/src/BigCommerce/Api/Customers/CustomersApi.php
@@ -93,6 +93,11 @@ class CustomersApi extends CustomerApiBase
         return new CustomerConsentApi($this->getClient(), null, $this->getResourceId());
     }
 
+    public function settings(): CustomerSettingsApi
+    {
+        return new CustomerSettingsApi($this->getClient());
+    }
+
     public function subscriber(int $id): SubscribersApi
     {
         return new SubscribersApi($this->getClient(), $id, $this->getParentResourceId());

--- a/src/BigCommerce/Api/Customers/CustomersApi.php
+++ b/src/BigCommerce/Api/Customers/CustomersApi.php
@@ -6,6 +6,7 @@ use BigCommerce\ApiV3\Api\Generic\DeleteInIdList;
 use BigCommerce\ApiV3\Api\Subscribers\SubscribersApi;
 use BigCommerce\ApiV3\ResponseModels\Customer\CustomersResponse;
 use BigCommerce\ApiV3\ResourceModels\Customer\Customer;
+use BigCommerce\ApiV3\ResponseModels\Customer\StoredInstrumentsResponse;
 use BigCommerce\ApiV3\ResponseModels\Customer\ValidateCredentialsResponse;
 use GuzzleHttp\RequestOptions;
 use UnexpectedValueException;
@@ -38,7 +39,7 @@ class CustomersApi extends CustomerApiBase
         if (count($customers) === 0) {
             return null;
         } elseif (count($customers) > 1) {
-            throw new UnexpectedValueException("There are more than one customer with the email address $email");
+            throw new UnexpectedValueException("There is more than one customer with the email address $email");
         }
 
         return $customers[0];
@@ -49,6 +50,15 @@ class CustomersApi extends CustomerApiBase
         $customers = $this->getAll([self::FILTER__ID_IN => $id])->getCustomers();
 
         return $customers[0] ?? null;
+    }
+
+    public function getStoredInstruments(): StoredInstrumentsResponse
+    {
+        $response = $this->getClient()->getRestClient()->get(
+            sprintf('customers/%d/stored-instruments', $this->getResourceId())
+        );
+
+        return new StoredInstrumentsResponse($response);
     }
 
     public function create(array $customers): CustomersResponse

--- a/src/BigCommerce/Api/Customers/CustomersApi.php
+++ b/src/BigCommerce/Api/Customers/CustomersApi.php
@@ -6,6 +6,8 @@ use BigCommerce\ApiV3\Api\Generic\DeleteInIdList;
 use BigCommerce\ApiV3\Api\Subscribers\SubscribersApi;
 use BigCommerce\ApiV3\ResponseModels\Customer\CustomersResponse;
 use BigCommerce\ApiV3\ResourceModels\Customer\Customer;
+use BigCommerce\ApiV3\ResponseModels\Customer\ValidateCredentialsResponse;
+use GuzzleHttp\RequestOptions;
 use UnexpectedValueException;
 
 class CustomersApi extends CustomerApiBase
@@ -57,6 +59,23 @@ class CustomersApi extends CustomerApiBase
     public function update(array $customers): CustomersResponse
     {
         return new CustomersResponse($this->updateResources($customers));
+    }
+
+    public function validateCredentials(string $email, string $password, ?int $channel_id = null): ValidateCredentialsResponse
+    {
+        $credentials = ['email' => $email, 'password' => $password];
+        if (!is_null($channel_id)) {
+            $credentials['channel_id'] = $channel_id;
+        }
+
+        $response = $this->getClient()->getRestClient()->post(
+            'customers/validate-credentials',
+            [
+                RequestOptions::JSON => $credentials,
+            ]
+        );
+
+        return new ValidateCredentialsResponse($response);
     }
 
     protected function resourceName(): string

--- a/src/BigCommerce/Api/Generic/ResourceApi.php
+++ b/src/BigCommerce/Api/Generic/ResourceApi.php
@@ -25,7 +25,7 @@ abstract class ResourceApi extends V3ApiBase
     protected function singleResourceUrl(): string
     {
         if (is_null($this->getResourceId())) {
-            throw new UnexpectedValueException("A {$this->resourceName()} id must be to be set");
+            throw new UnexpectedValueException("A {$this->resourceName()} id must be set");
         }
 
         return sprintf(

--- a/src/BigCommerce/Client.php
+++ b/src/BigCommerce/Client.php
@@ -89,6 +89,11 @@ class Client extends BaseApiClient
         return new CatalogApi($this);
     }
 
+    public function customer(int $customerId): CustomersApi
+    {
+        return new CustomersApi($this, $customerId);
+    }
+
     public function customers(): CustomersApi
     {
         return new CustomersApi($this);

--- a/src/BigCommerce/ResourceModels/Customer/CustomerChannelSettings.php
+++ b/src/BigCommerce/ResourceModels/Customer/CustomerChannelSettings.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResourceModels\Customer;
+
+use BigCommerce\ApiV3\ResourceModels\Customer\CustomerSettings\CustomerGroupSettings;
+use BigCommerce\ApiV3\ResourceModels\Customer\CustomerSettings\PrivacySettings;
+use BigCommerce\ApiV3\ResourceModels\ResourceModel;
+
+class CustomerChannelSettings extends ResourceModel
+{
+    public PrivacySettings $privacy_settings;
+    public CustomerGroupSettings $customer_group_settings;
+
+    /**
+     * Determines if a channel allows global customer to login
+     * Determines if customers created on this channel will get global access/login
+     */
+    public ?bool $allow_global_logins;
+
+    protected function beforeBuildObject(): void
+    {
+        $this->buildPropertyObject('privacy_settings', PrivacySettings::class);
+        $this->buildPropertyObject('customer_group_settings', CustomerGroupSettings::class);
+
+        parent::beforeBuildObject();
+    }
+}

--- a/src/BigCommerce/ResourceModels/Customer/CustomerCredentialsValidation.php
+++ b/src/BigCommerce/ResourceModels/Customer/CustomerCredentialsValidation.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResourceModels\Customer;
+
+use BigCommerce\ApiV3\ResourceModels\ResourceModel;
+
+class CustomerCredentialsValidation extends ResourceModel
+{
+    public ?int $customer_id;
+    public bool $is_valid;
+}

--- a/src/BigCommerce/ResourceModels/Customer/CustomerSettings.php
+++ b/src/BigCommerce/ResourceModels/Customer/CustomerSettings.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResourceModels\Customer;
+
+use BigCommerce\ApiV3\ResourceModels\Customer\CustomerSettings\CustomerGroupSettings;
+use BigCommerce\ApiV3\ResourceModels\Customer\CustomerSettings\PrivacySettings;
+use BigCommerce\ApiV3\ResourceModels\ResourceModel;
+
+class CustomerSettings extends ResourceModel
+{
+    public PrivacySettings $privacy_settings;
+    public CustomerGroupSettings $customer_group_settings;
+
+    protected function beforeBuildObject(): void
+    {
+        $this->buildPropertyObject('privacy_settings', PrivacySettings::class);
+        $this->buildPropertyObject('customer_group_settings', CustomerGroupSettings::class);
+
+        parent::beforeBuildObject();
+    }
+}

--- a/src/BigCommerce/ResourceModels/Customer/CustomerSettings/CustomerGroupSettings.php
+++ b/src/BigCommerce/ResourceModels/Customer/CustomerSettings/CustomerGroupSettings.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResourceModels\Customer\CustomerSettings;
+
+use BigCommerce\ApiV3\ResourceModels\ResourceModel;
+
+class CustomerGroupSettings extends ResourceModel
+{
+    public int $guest_customer_group_id;
+    public int $default_customer_group_id;
+}

--- a/src/BigCommerce/ResourceModels/Customer/CustomerSettings/CustomerGroupSettings.php
+++ b/src/BigCommerce/ResourceModels/Customer/CustomerSettings/CustomerGroupSettings.php
@@ -6,6 +6,6 @@ use BigCommerce\ApiV3\ResourceModels\ResourceModel;
 
 class CustomerGroupSettings extends ResourceModel
 {
-    public int $guest_customer_group_id;
-    public int $default_customer_group_id;
+    public ?int $guest_customer_group_id;
+    public ?int $default_customer_group_id;
 }

--- a/src/BigCommerce/ResourceModels/Customer/CustomerSettings/PrivacySettings.php
+++ b/src/BigCommerce/ResourceModels/Customer/CustomerSettings/PrivacySettings.php
@@ -9,13 +9,13 @@ class PrivacySettings extends ResourceModel
     /**
      * Determines if a customer requires consent for tracking privacy.
      */
-    public bool $ask_shopper_for_tracking_consent;
+    public ?bool $ask_shopper_for_tracking_consent;
 
     /**
      * The URL for a website's privacy policy.
      * Example: https://bigcommmerce.com/policy
      */
-    public string $policy_url;
+    public ?string $policy_url;
 
-    public bool $ask_shopper_for_tracking_consent_on_checkout;
+    public ?bool $ask_shopper_for_tracking_consent_on_checkout;
 }

--- a/src/BigCommerce/ResourceModels/Customer/CustomerSettings/PrivacySettings.php
+++ b/src/BigCommerce/ResourceModels/Customer/CustomerSettings/PrivacySettings.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResourceModels\Customer\CustomerSettings;
+
+use BigCommerce\ApiV3\ResourceModels\ResourceModel;
+
+class PrivacySettings extends ResourceModel
+{
+    /**
+     * Determines if a customer requires consent for tracking privacy.
+     */
+    public bool $ask_shopper_for_tracking_consent;
+
+    /**
+     * The URL for a website's privacy policy.
+     * Example: https://bigcommmerce.com/policy
+     */
+    public string $policy_url;
+
+    public bool $ask_shopper_for_tracking_consent_on_checkout;
+}

--- a/src/BigCommerce/ResourceModels/Customer/StoredInstruments/CardBillingAddress.php
+++ b/src/BigCommerce/ResourceModels/Customer/StoredInstruments/CardBillingAddress.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResourceModels\Customer\StoredInstruments;
+
+use BigCommerce\ApiV3\ResourceModels\ResourceModel;
+
+class CardBillingAddress extends ResourceModel
+{
+    public string $first_name;
+    public string $last_name;
+    public string $company;
+    public string $address1;
+    public string $address2;
+    public string $city;
+    public string $state_or_province;
+    public string $postal_code;
+    public string $country_code;
+    public string $state_or_province_code;
+    public string $phone;
+    public string $email;
+}

--- a/src/BigCommerce/ResourceModels/Customer/StoredInstruments/StoredBankAccount.php
+++ b/src/BigCommerce/ResourceModels/Customer/StoredInstruments/StoredBankAccount.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResourceModels\Customer\StoredInstruments;
+
+class StoredBankAccount extends StoredInstrument
+{
+    public string $masked_account_number;
+    public string $issuer;
+}

--- a/src/BigCommerce/ResourceModels/Customer/StoredInstruments/StoredCard.php
+++ b/src/BigCommerce/ResourceModels/Customer/StoredInstruments/StoredCard.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResourceModels\Customer\StoredInstruments;
+
+class StoredCard extends StoredInstrument
+{
+    public string $brand;
+    public string $expiry_month;
+    public string $expiry_year;
+
+    public string $issuer_identification_number;
+    public string $last_4;
+    public CardBillingAddress $billing_address;
+
+    protected function beforeBuildObject(): void
+    {
+        $this->buildPropertyObject('billing_address', CardBillingAddress::class);
+        parent::beforeBuildObject();
+    }
+}

--- a/src/BigCommerce/ResourceModels/Customer/StoredInstruments/StoredInstrument.php
+++ b/src/BigCommerce/ResourceModels/Customer/StoredInstruments/StoredInstrument.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResourceModels\Customer\StoredInstruments;
+
+use BigCommerce\ApiV3\ResourceModels\ResourceModel;
+
+class StoredInstrument extends ResourceModel
+{
+    public const TYPE__CARD = 'stored_card';
+    public const TYPE__PAYPAL = 'stored_paypal_account';
+    public const TYPE__BANK_ACCOUNT = 'stored_bank_account';
+
+    public string $type;
+    public string $token;
+    public bool $is_default;
+}

--- a/src/BigCommerce/ResourceModels/Customer/StoredInstruments/StoredInstrumentFactory.php
+++ b/src/BigCommerce/ResourceModels/Customer/StoredInstruments/StoredInstrumentFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResourceModels\Customer\StoredInstruments;
+
+class StoredInstrumentFactory
+{
+    private array $map = [
+        StoredInstrument::TYPE__BANK_ACCOUNT => StoredBankAccount::class,
+        StoredInstrument::TYPE__CARD         => StoredCard::class,
+        StoredInstrument::TYPE__PAYPAL       => StoredPaypalAccount::class,
+    ];
+
+    public function build(object $storedInstrumentData): StoredInstrument
+    {
+        if (array_key_exists($storedInstrumentData->type, $this->map)) {
+            return new $this->map[$storedInstrumentData->type]($storedInstrumentData);
+        }
+
+        throw new \UnexpectedValueException("Unrecognised stored instrument '{$storedInstrumentData->type}'");
+    }
+}

--- a/src/BigCommerce/ResourceModels/Customer/StoredInstruments/StoredPaypalAccount.php
+++ b/src/BigCommerce/ResourceModels/Customer/StoredInstruments/StoredPaypalAccount.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResourceModels\Customer\StoredInstruments;
+
+class StoredPaypalAccount extends StoredInstrument
+{
+    public string $email;
+}

--- a/src/BigCommerce/ResponseModels/Customer/CustomerChannelSettingsResponse.php
+++ b/src/BigCommerce/ResponseModels/Customer/CustomerChannelSettingsResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResponseModels\Customer;
+
+use BigCommerce\ApiV3\ResourceModels\Customer\CustomerChannelSettings;
+use BigCommerce\ApiV3\ResponseModels\SingleResourceResponse;
+use stdClass;
+
+class CustomerChannelSettingsResponse extends SingleResourceResponse
+{
+    private CustomerChannelSettings $channelSettings;
+
+    public function getChannelSettings(): CustomerChannelSettings
+    {
+        return $this->channelSettings;
+    }
+
+    protected function addData(stdClass $rawData): void
+    {
+        $this->channelSettings = new CustomerChannelSettings($rawData);
+    }
+}

--- a/src/BigCommerce/ResponseModels/Customer/CustomerSettingsResponse.php
+++ b/src/BigCommerce/ResponseModels/Customer/CustomerSettingsResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResponseModels\Customer;
+
+use BigCommerce\ApiV3\ResourceModels\Customer\CustomerSettings;
+use BigCommerce\ApiV3\ResponseModels\SingleResourceResponse;
+use stdClass;
+
+class CustomerSettingsResponse extends SingleResourceResponse
+{
+    private CustomerSettings $customerSettings;
+
+    public function getCustomerSettings(): CustomerSettings
+    {
+        return $this->customerSettings;
+    }
+
+    protected function addData(stdClass $rawData): void
+    {
+        $this->customerSettings = new CustomerSettings($rawData);
+    }
+}

--- a/src/BigCommerce/ResponseModels/Customer/StoredInstrumentsResponse.php
+++ b/src/BigCommerce/ResponseModels/Customer/StoredInstrumentsResponse.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResponseModels\Customer;
+
+use BigCommerce\ApiV3\ResourceModels\Customer\StoredInstruments\StoredBankAccount;
+use BigCommerce\ApiV3\ResourceModels\Customer\StoredInstruments\StoredCard;
+use BigCommerce\ApiV3\ResourceModels\Customer\StoredInstruments\StoredInstrument;
+use BigCommerce\ApiV3\ResourceModels\Customer\StoredInstruments\StoredInstrumentFactory;
+use BigCommerce\ApiV3\ResourceModels\Customer\StoredInstruments\StoredPaypalAccount;
+use Psr\Http\Message\ResponseInterface;
+
+class StoredInstrumentsResponse
+{
+    /**
+     * @var StoredInstrument[]
+     */
+    private array $storedInstruments;
+    public function __construct(ResponseInterface $response)
+    {
+        $rawData = json_decode($response->getBody());
+        $this->addInstruments($rawData);
+    }
+
+    private function addInstruments(array $rawData)
+    {
+        $instrumentFactory = new StoredInstrumentFactory();
+        $this->storedInstruments = array_map(fn($instrument) => $instrumentFactory->build($instrument), $rawData);
+    }
+
+    /**
+     * @return StoredCard[]|StoredBankAccount[]|StoredPaypalAccount[]
+     */
+    public function getStoredInstruments(): array
+    {
+        return $this->storedInstruments;
+    }
+}

--- a/src/BigCommerce/ResponseModels/Customer/ValidateCredentialsResponse.php
+++ b/src/BigCommerce/ResponseModels/Customer/ValidateCredentialsResponse.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace BigCommerce\ApiV3\ResponseModels\Customer;
+
+use BigCommerce\ApiV3\ResourceModels\Customer\CustomerCredentialsValidation;
+use BigCommerce\ApiV3\ResponseModels\SingleResourceResponse;
+use Psr\Http\Message\ResponseInterface;
+use stdClass;
+
+class ValidateCredentialsResponse extends SingleResourceResponse
+{
+    private CustomerCredentialsValidation $credentialsValidation;
+
+    protected function decodeResponseBody(object $responseBody): object
+    {
+        return $responseBody;
+    }
+
+    public function getCredentialsValidation(): CustomerCredentialsValidation
+    {
+        return $this->credentialsValidation;
+    }
+
+    protected function addData(stdClass $rawData): void
+    {
+        $this->credentialsValidation = new CustomerCredentialsValidation($rawData);
+    }
+}

--- a/src/BigCommerce/ResponseModels/Customer/ValidateCredentialsResponse.php
+++ b/src/BigCommerce/ResponseModels/Customer/ValidateCredentialsResponse.php
@@ -4,7 +4,6 @@ namespace BigCommerce\ApiV3\ResponseModels\Customer;
 
 use BigCommerce\ApiV3\ResourceModels\Customer\CustomerCredentialsValidation;
 use BigCommerce\ApiV3\ResponseModels\SingleResourceResponse;
-use Psr\Http\Message\ResponseInterface;
 use stdClass;
 
 class ValidateCredentialsResponse extends SingleResourceResponse

--- a/src/BigCommerce/ResponseModels/SingleResourceResponse.php
+++ b/src/BigCommerce/ResponseModels/SingleResourceResponse.php
@@ -9,7 +9,12 @@ abstract class SingleResourceResponse
 {
     public function __construct(ResponseInterface $response)
     {
-        $this->addData(json_decode($response->getBody())->data);
+        $this->addData($this->decodeResponseBody(json_decode($response->getBody())));
+    }
+
+    protected function decodeResponseBody(object $responseBody): object
+    {
+        return $responseBody->data;
     }
 
     abstract protected function addData(stdClass $rawData): void;

--- a/tests/BigCommerce/Api/Customers/CustomerSettingsApiTest.php
+++ b/tests/BigCommerce/Api/Customers/CustomerSettingsApiTest.php
@@ -14,4 +14,12 @@ class CustomerSettingsApiTest extends BigCommerceApiTest
 
         $this->assertEquals('https://bigcommmerce.com/policy', $settings->privacy_settings->policy_url);
     }
+
+    public function testCanGetCustomerSettingsPerChannel()
+    {
+        $this->setReturnData('customers__settings__by_channel.json');
+        $settings = $this->getApi()->customers()->settings()->channel(1)->get()->getChannelSettings();
+
+        $this->assertEquals('https://aligent.com.au/takeflight', $settings->privacy_settings->policy_url);
+    }
 }

--- a/tests/BigCommerce/Api/Customers/CustomerSettingsApiTest.php
+++ b/tests/BigCommerce/Api/Customers/CustomerSettingsApiTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace BigCommerce\Tests\Api\Customers;
+
+use BigCommerce\Tests\BigCommerceApiTest;
+
+class CustomerSettingsApiTest extends BigCommerceApiTest
+{
+    public function testCanGetCustomerSettings()
+    {
+        $this->setReturnData('customers__settings__get.json');
+
+        $settings = $this->getApi()->customers()->settings()->get()->getCustomerSettings();
+
+        $this->assertEquals('https://bigcommmerce.com/policy', $settings->privacy_settings->policy_url);
+    }
+}

--- a/tests/BigCommerce/Api/Customers/CustomersApiTest.php
+++ b/tests/BigCommerce/Api/Customers/CustomersApiTest.php
@@ -90,4 +90,14 @@ class CustomersApiTest extends BigCommerceApiTest
 
         $this->assertFalse($validation->getCredentialsValidation()->is_valid);
     }
+
+    public function testCanGetStoredInstruments()
+    {
+        $this->setReturnData('customers__stored_instruments__get.json');
+
+        $instruments = $this->getApi()->customer(1)->getStoredInstruments()->getStoredInstruments();
+
+        $this->assertCount(3, $instruments);
+        $this->assertEquals('VISA', $instruments[0]->brand);
+    }
 }

--- a/tests/BigCommerce/Api/Customers/CustomersApiTest.php
+++ b/tests/BigCommerce/Api/Customers/CustomersApiTest.php
@@ -81,4 +81,13 @@ class CustomersApiTest extends BigCommerceApiTest
 
         $this->assertTrue($this->getApi()->customers()->delete([1, 2]));
     }
+
+    public function testCanValidateCredentials()
+    {
+        $this->setReturnData('customers__validate-credentials.json');
+
+        $validation = $this->getApi()->customers()->validateCredentials('john.smith@example.com', 'Password123');
+
+        $this->assertFalse($validation->getCredentialsValidation()->is_valid);
+    }
 }

--- a/tests/BigCommerce/responses/customers__settings__by_channel.json
+++ b/tests/BigCommerce/responses/customers__settings__by_channel.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "privacy_settings": {
+      "ask_shopper_for_tracking_consent": null,
+      "policy_url": "https://aligent.com.au/takeflight",
+      "ask_shopper_for_tracking_consent_on_checkout": null
+    },
+    "customer_group_settings": {
+      "guest_customer_group_id": null,
+      "default_customer_group_id": null
+    },
+    "allow_global_logins": true
+  }
+}

--- a/tests/BigCommerce/responses/customers__settings__get.json
+++ b/tests/BigCommerce/responses/customers__settings__get.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+    "privacy_settings": {
+      "ask_shopper_for_tracking_consent": false,
+      "policy_url": "https://bigcommmerce.com/policy",
+      "ask_shopper_for_tracking_consent_on_checkout": false
+    },
+    "customer_group_settings": {
+      "guest_customer_group_id": 0,
+      "default_customer_group_id": 0
+    }
+  }
+}

--- a/tests/BigCommerce/responses/customers__stored_instruments__get.json
+++ b/tests/BigCommerce/responses/customers__stored_instruments__get.json
@@ -1,0 +1,39 @@
+[
+  {
+    "type": "stored_card",
+    "token": "84596bea275fa254da820056bdc3e495bdf01fd11c51b0336347d447ee16200c",
+    "is_default": true,
+    "brand": "VISA",
+    "expiry_month": 1,
+    "expiry_year": 0,
+    "issuer_identification_number": "411111",
+    "last_4": "1111",
+    "billing_address": {
+      "first_name": "Tester",
+      "last_name": "Tester",
+      "email": "example@email.com",
+      "company": "Test Company",
+      "address1": "1 Sample Street",
+      "address2": "Apt 1",
+      "city": "Las Vegas",
+      "postal_code": "90854",
+      "state_or_province": "Nevada",
+      "state_or_province_code": "NV",
+      "country_code": "US",
+      "phone": "101-192-0293"
+    }
+  },
+  {
+    "type": "stored_paypal_account",
+    "token": "dfghjkl4a275fa254da820056bdc3e495bdf01fd11c51b0336347d447ee16200c",
+    "is_default": false,
+    "email": "bc-buyer-paypal-express@example.com"
+  },
+  {
+    "type": "stored_bank_account",
+    "token": "536475f687vbyinfgdfdgfdg0056bdc3e495bdf01fd11c51b0336347d447ee16200c",
+    "is_default": false,
+    "masked_account_number": "12XXX56",
+    "issuer": "DE001"
+  }
+]

--- a/tests/BigCommerce/responses/customers__validate-credentials.json
+++ b/tests/BigCommerce/responses/customers__validate-credentials.json
@@ -1,0 +1,3 @@
+{
+  "is_valid": false
+}


### PR DESCRIPTION
Adds some of the stranger endpoints on Customer. It's quite different to other endpoints, but this adds access to 

- [Get stored instruments](https://developer.bigcommerce.com/api-reference/b735a25b3a0b8-get-stored-instruments)
- [Customer Settings](https://developer.bigcommerce.com/api-reference/0c31a6d25e5ea-get-customer-settings)
- [Customer Settings per Channel](https://developer.bigcommerce.com/api-reference/d5e66c45b0415-get-customer-settings-per-channel)
- [Validate credentials](https://developer.bigcommerce.com/api-reference/3d731215a3dcb-validate-a-customer-credentials)

Fixes #181 