### PR TITLE
Allow nullable variant id in Product Complex Rule Conditions

### DIFF
--- a/src/BigCommerce/ResourceModels/Catalog/Product/ComplexRuleConditions.php
+++ b/src/BigCommerce/ResourceModels/Catalog/Product/ComplexRuleConditions.php
@@ -9,6 +9,6 @@ class ComplexRuleConditions extends ResourceModel
     public int $rule_id;
     public int $modifier_id;
     public int $modifier_value_id;
-    public int $variant_id;
+    public ?int $variant_id;
     public int $combination_id;
 }

--- a/src/BigCommerce/ResourceModels/Catalog/Product/ComplexRuleConditions.php
+++ b/src/BigCommerce/ResourceModels/Catalog/Product/ComplexRuleConditions.php
@@ -9,6 +9,6 @@ class ComplexRuleConditions extends ResourceModel
     public int $rule_id;
     public int $modifier_id;
     public int $modifier_value_id;
-    public array $variant_id;
+    public int $variant_id;
     public int $combination_id;
 }


### PR DESCRIPTION
The variant_id in complex rules conditions is not array but the integer as per documentation.

![image](https://user-images.githubusercontent.com/10668308/236656244-d3e46696-6408-4442-8edb-c37e5f326536.png)