### PR TITLE
Allow nullable variant id in Product Complex Rule Conditions

### DIFF
--- a/src/BigCommerce/ResourceModels/Catalog/Product/ComplexRuleConditions.php
+++ b/src/BigCommerce/ResourceModels/Catalog/Product/ComplexRuleConditions.php
@@ -9,6 +9,6 @@ class ComplexRuleConditions extends ResourceModel
     public int $rule_id;
     public int $modifier_id;
     public int $modifier_value_id;
-    public array $variant_id;
+    public ?int $variant_id;
     public int $combination_id;
 }

--- a/src/BigCommerce/ResourceModels/Catalog/Product/PriceAdjuster.php
+++ b/src/BigCommerce/ResourceModels/Catalog/Product/PriceAdjuster.php
@@ -16,7 +16,7 @@ class PriceAdjuster extends ResourceModel
     {
         if (!is_null($this->optionObject)) {
             if(is_null($this->optionObject->adjuster)){
-                $this->optionObject->adjuster = ADJUSTER_FIXED;
+                $this->optionObject->adjuster = self::ADJUSTER_FIXED;
             }
         }
     }

--- a/src/BigCommerce/ResourceModels/Catalog/Product/PriceAdjuster.php
+++ b/src/BigCommerce/ResourceModels/Catalog/Product/PriceAdjuster.php
@@ -11,4 +11,13 @@ class PriceAdjuster extends ResourceModel
 
     public string $adjuster;
     public float $adjuster_value;
+    
+    protected function beforeBuildObject(): void
+    {
+        if (!is_null($this->optionObject)) {
+            if(is_null($this->optionObject->adjuster)){
+                $this->optionObject->adjuster = ADJUSTER_FIXED;
+            }
+        }
+    }
 }

--- a/src/BigCommerce/ResourceModels/Catalog/Product/WeightAdjuster.php
+++ b/src/BigCommerce/ResourceModels/Catalog/Product/WeightAdjuster.php
@@ -16,7 +16,7 @@ class WeightAdjuster extends ResourceModel
     {
         if (!is_null($this->optionObject)) {
             if(is_null($this->optionObject->adjuster)){
-                $this->optionObject->adjuster = ADJUSTER_FIXED;
+                $this->optionObject->adjuster = self::ADJUSTER_FIXED;
             }
         }
     }

--- a/src/BigCommerce/ResourceModels/Catalog/Product/WeightAdjuster.php
+++ b/src/BigCommerce/ResourceModels/Catalog/Product/WeightAdjuster.php
@@ -6,6 +6,18 @@ use BigCommerce\ApiV3\ResourceModels\ResourceModel;
 
 class WeightAdjuster extends ResourceModel
 {
+    public const ADJUSTER_RELATIVE = 'relative';
+    public const ADJUSTER_FIXED    = 'fixed';
+
     public string $adjuster;
     public float $adjuster_value;
+    
+    protected function beforeBuildObject(): void
+    {
+        if (!is_null($this->optionObject)) {
+            if(is_null($this->optionObject->adjuster)){
+                $this->optionObject->adjuster = ADJUSTER_FIXED;
+            }
+        }
+    }
 }

--- a/src/BigCommerce/ResourceModels/ResourceModel.php
+++ b/src/BigCommerce/ResourceModels/ResourceModel.php
@@ -7,7 +7,7 @@ use stdClass;
 
 abstract class ResourceModel implements JsonSerializable
 {
-    private ?stdClass $optionObject;
+    protected ?stdClass $optionObject;
 
     public function __construct(?stdClass $optionObject = null)
     {


### PR DESCRIPTION
Allow null values for variant id in complex rule condition.
The variant_id in complex rules conditions is not array but the integer as per documentation.

![image](https://user-images.githubusercontent.com/10668308/236656244-d3e46696-6408-4442-8edb-c37e5f326536.png)