### PR TITLE
Fixed null meta description error in Product resource

### DIFF
--- a/src/BigCommerce/ResourceModels/Catalog/Product/Product.php
+++ b/src/BigCommerce/ResourceModels/Catalog/Product/Product.php
@@ -63,7 +63,7 @@ class Product extends ResourceModel
     public int $order_quantity_maximum;
     public string $page_title;
     public array $meta_keywords;
-    public string $meta_description;
+    public ?string $meta_description;
     public string $date_created;
     public string $date_modified;
     public int $view_count;


### PR DESCRIPTION
Fixed an exception thrown when meta description is null

TypeError: Cannot assign null to property BigCommerce\ApiV3\ResourceModels\Catalog\Product\Product::$meta_description of type string